### PR TITLE
Use canonical MIT license URL

### DIFF
--- a/src/licenses/mit.ts
+++ b/src/licenses/mit.ts
@@ -43,7 +43,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
         let template = `Copyright (c) ${ this.year } ${ this.author }
 
 This software is released under the MIT License.
-http://opensource.org/licenses/mit-license.php`;
+https://opensource.org/licenses/MIT`;
         return template;
     }
 }


### PR DESCRIPTION
The currently used MIT license URL references the old PHP-file based license at
http://opensource.org/licenses/mit-license.php and uses the HTTP scheme.

It got replaced with the canonical URL (https://opensource.org/licenses/MIT).