### PR TITLE
Remove multiple spaces before author name in GPL licenses

### DIFF
--- a/src/licenses/gplv2.ts
+++ b/src/licenses/gplv2.ts
@@ -372,7 +372,7 @@ Public License instead of this License.`
     }
 
     public header(): string {
-        let template = `Copyright (C) ${ this.year }  ${ this.author }
+        let template = `Copyright (C) ${ this.year } ${ this.author }
 
 This file is part of ${ this.productName }.
 

--- a/src/licenses/gplv3.ts
+++ b/src/licenses/gplv3.ts
@@ -264,7 +264,7 @@ The GNU General Public License does not permit incorporating your program into p
     }
 
     public header(): string {
-        let template = `Copyright (C) ${ this.year }  ${ this.author }
+        let template = `Copyright (C) ${ this.year } ${ this.author }
 
 This file is part of ${ this.productName }.
 


### PR DESCRIPTION
There's two spaces before author name in GPL licenses.

```
/**
 * Copyright (C) 2017  Kok Sam.
 *
 * This file is part of Project.
 *
 * Project is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
 *
 * Project is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
 *
 * You should have received a copy of the GNU General Public License
 * along with Project.  If not, see <http://www.gnu.org/licenses/>.
 *
 */
```