### PR TITLE
add support for the D programming language

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Programming languages supported in this extension are (alphabetical order):
 * C++
 * C#
 * CSS
+* D
 * Dockerfile
 * Erlang
 * F#
@@ -182,6 +183,7 @@ Thank you for contributions to "licenser".
 * @jrobeson
 * @dlech
 * @Lexicality
+* @detwin
 
 ## Reference
 * [All CC 3.0 Legal Codes](https://creativecommons.org/2011/04/15/plaintext-versions-of-creative-commons-licenses-and-cc0/)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,18 @@
     ],
     "main": "./out/src/extension",
     "contributes": {
-        "languages": [{
+        "languages": [
+            {
+                "id": "d",
+                "extensions": [
+                    ".d",
+                    ".di"
+                ],
+                "aliases": [
+                    "D"
+                ]
+            },
+            {
                 "id": "ocaml",
                 "extensions": [
                     ".ml",

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -94,6 +94,7 @@ const swift = new Notation("swift", ["/**", " */"], "//", " * ");
 const xml = new Notation("xml", ["<!--", "-->"], "", "");
 
 // custom languages
+const d = new Notation( "d", ["/*", " */"], "//", " *");
 const erlang = new Notation("erlang", ["", ""], "%%", "");
 const haskell = new Notation("haskell", ["{--", "-}"], "--", " - ");
 const lisp = new Notation("lisp", ["", ""], ";;", "");
@@ -138,6 +139,7 @@ export const notations: {[key: string]: Notation} = {
     "swift": swift,
     "xml": xml,
 
+    "d": d,
     "erlang": erlang,
     "haskell": haskell,
     "lisp": lisp,


### PR DESCRIPTION
for the D programming language it actually shall be "/* */" instead of "/** */", because otherwise it would become part of the imbedded documentation. and that shouldnt be the default behaviour. see:  https://dlang.org/spec/ddoc.html#lexical