### PR TITLE
Support has been added for Julia, Crystal, Nim and Nimble

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,12 @@ Programming languages supported in this extension are (alphabetical order):
 
 Following programing languages are supported in the manuaul configurations in this extension.
 (See `contributes.languages` in `package.json`)
+* Crystal
 * Erlang
 * Haskell
+* Julia
 * LISP (CommonLisp, Scheme)
+* Nim (and Nimble)
 * OCaml
 * Pascal
 
@@ -188,6 +191,7 @@ Thank you for contributions to "licenser".
 * @Lexicality
 * @detwin
 * @teo-tsirpanis
+* @olefasting
 
 ## Reference
 * [All CC 3.0 Legal Codes](https://creativecommons.org/2011/04/15/plaintext-versions-of-creative-commons-licenses-and-cc0/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,161 +2,51 @@
     "name": "licenser",
     "version": "1.1.1",
     "lockfileVersion": 1,
+    "requires": true,
     "dependencies": {
         "@types/mocha": {
-            "version": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.40.tgz",
-            "integrity": "sha1-mBHdgA7OVEzYS1uFmRe/WEoVDEw=",
+            "version": "2.2.44",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.44.tgz",
+            "integrity": "sha512-k2tWTQU8G4+iSMvqKi0Q9IIsWAp/n8xzdZS4Q4YVIltApoMA00wFBFdlJnmoaK1/z7B0Cy0yPe6GgXteSmdUNw==",
             "dev": true
         },
         "@types/node": {
-            "version": "https://registry.npmjs.org/@types/node/-/node-6.0.68.tgz",
-            "integrity": "sha1-DEO2uLlEX+uGoPvTRX4/S8WR5m0="
-        },
-        "ajv": {
-            "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
-            "integrity": "sha1-tu50ZXuZOgHc5Et5RNVvSFgo1b0=",
-            "dev": true
-        },
-        "ansi-align": {
-            "version": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
-            "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
-            "dev": true,
-            "dependencies": {
-                "string-width": {
-                    "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "dev": true
-                }
-            }
-        },
-        "ansi-regex": {
-            "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "dev": true
-        },
-        "ansi-styles": {
-            "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-            "dev": true
+            "version": "6.0.90",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.90.tgz",
+            "integrity": "sha512-tXoGRVdi7wZX7P1VWoV9Wfk0uYDOAHdEYXAttuWgSrN76Q32wQlSrMX0Rgyv3RTEaQY2ZLQrzYHVM2e8rfo8sA=="
         },
         "argparse": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY="
-        },
-        "arr-diff": {
-            "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-            "dev": true
-        },
-        "arr-flatten": {
-            "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-            "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
-            "dev": true
-        },
-        "array-differ": {
-            "version": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-            "dev": true
-        },
-        "array-union": {
-            "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "dev": true
-        },
-        "array-uniq": {
-            "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true
-        },
-        "array-unique": {
-            "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-            "dev": true
-        },
-        "arrify": {
-            "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-            "dev": true
-        },
-        "asn1": {
-            "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-            "dev": true
-        },
-        "assert-plus": {
-            "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-            "dev": true
-        },
-        "asynckit": {
-            "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-            "dev": true
-        },
-        "aws-sign2": {
-            "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-            "dev": true
-        },
-        "aws4": {
-            "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-            "dev": true
-        },
-        "babel-code-frame": {
-            "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-            "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-            "dev": true
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "requires": {
+                "sprintf-js": "1.0.3"
+            }
         },
         "balanced-match": {
             "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
             "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
         },
-        "bcrypt-pbkdf": {
-            "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-            "dev": true,
-            "optional": true
-        },
-        "beeper": {
-            "version": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-            "dev": true
-        },
         "block-stream": {
             "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            }
         },
         "boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
         },
-        "boom": {
-            "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-            "dev": true
-        },
-        "boxen": {
-            "version": "https://registry.npmjs.org/boxen/-/boxen-1.0.0.tgz",
-            "integrity": "sha1-smlLrx9gX3CP8Bd8Ehk7IvKaqqs=",
-            "dev": true
-        },
         "brace-expansion": {
             "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-            "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk="
-        },
-        "braces": {
-            "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-            "dev": true
-        },
-        "browser-stdout": {
-            "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-            "dev": true
+            "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+            "requires": {
+                "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+            }
         },
         "buffer-crc32": {
             "version": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -166,179 +56,128 @@
             "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
             "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
         },
-        "camelcase": {
-            "version": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-            "dev": true
-        },
-        "capture-stack-trace": {
-            "version": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-            "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-            "dev": true
-        },
-        "caseless": {
-            "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-            "dev": true
-        },
-        "chalk": {
-            "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-            "dev": true
-        },
         "cheerio": {
             "version": "1.0.0-rc.2",
             "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
-            "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs="
+            "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+            "requires": {
+                "css-select": "1.2.0",
+                "dom-serializer": "0.1.0",
+                "entities": "1.1.1",
+                "htmlparser2": "3.9.2",
+                "lodash": "4.17.4",
+                "parse5": "3.0.2"
+            }
         },
-        "cli-boxes": {
-            "version": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-            "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-            "dev": true
+        "color-convert": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
         },
-        "clone": {
-            "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-            "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
-            "dev": true
-        },
-        "clone-buffer": {
-            "version": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-            "dev": true
-        },
-        "clone-stats": {
-            "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-            "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-            "dev": true
-        },
-        "cloneable-readable": {
-            "version": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
-            "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
-            "dev": true
-        },
-        "co": {
-            "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-            "dev": true
-        },
-        "code-point-at": {
-            "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "dev": true
-        },
-        "colors": {
-            "version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-            "dev": true
-        },
-        "combined-stream": {
-            "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
         "commander": {
             "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
+            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+            "requires": {
+                "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+            }
         },
         "concat-map": {
             "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
-        "configstore": {
-            "version": "https://registry.npmjs.org/configstore/-/configstore-3.0.0.tgz",
-            "integrity": "sha1-4bhmnBgDzMULVF6S+ObnmqgOAZY=",
-            "dev": true
-        },
-        "convert-source-map": {
-            "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-            "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
-            "dev": true
-        },
         "core-util-is": {
             "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
-        "create-error-class": {
-            "version": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-            "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-            "dev": true
-        },
-        "cross-spawn-async": {
-            "version": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
-            "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
-            "dev": true
-        },
-        "cryptiles": {
-            "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-            "dev": true
-        },
-        "crypto-random-string": {
-            "version": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-            "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-            "dev": true
+        "cross-spawn": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "dev": true,
+            "requires": {
+                "lru-cache": "4.1.1",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+            },
+            "dependencies": {
+                "isexe": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                    "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+                    "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
+                    }
+                },
+                "pseudomap": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                    "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+                    "dev": true
+                },
+                "which": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+                    "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "2.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+                    "dev": true
+                }
+            }
         },
         "css-select": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-            "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg="
+            "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+            "requires": {
+                "boolbase": "1.0.0",
+                "css-what": "2.1.0",
+                "domutils": "1.5.1",
+                "nth-check": "1.0.1"
+            }
         },
         "css-what": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
             "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
         },
-        "dashdash": {
-            "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "dev": true,
-            "dependencies": {
-                "assert-plus": {
-                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
-            }
-        },
-        "dateformat": {
-            "version": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-            "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
-            "dev": true
-        },
-        "debug": {
-            "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-            "dev": true
-        },
-        "deep-assign": {
-            "version": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
-            "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
-            "dev": true
-        },
-        "deep-extend": {
-            "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-            "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
-            "dev": true
-        },
-        "delayed-stream": {
-            "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-            "dev": true
-        },
         "denodeify": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
             "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE="
         },
-        "diff": {
-            "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-            "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-            "dev": true
-        },
         "dom-serializer": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+            "requires": {
+                "domelementtype": "1.1.3",
+                "entities": "1.1.1"
+            },
             "dependencies": {
                 "domelementtype": {
                     "version": "1.1.3",
@@ -355,66 +194,18 @@
         "domhandler": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
-            "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk="
+            "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+            "requires": {
+                "domelementtype": "1.3.0"
+            }
         },
         "domutils": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8="
-        },
-        "dot-prop": {
-            "version": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
-            "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
-            "dev": true
-        },
-        "duplexer": {
-            "version": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-            "dev": true
-        },
-        "duplexer2": {
-            "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-            "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-            "dev": true,
-            "dependencies": {
-                "isarray": {
-                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "dev": true
-                }
-            }
-        },
-        "duplexer3": {
-            "version": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-            "dev": true
-        },
-        "duplexify": {
-            "version": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
-            "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
-            "dev": true
-        },
-        "ecc-jsbn": {
-            "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-            "dev": true,
-            "optional": true
-        },
-        "end-of-stream": {
-            "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-            "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
-            "dev": true,
-            "dependencies": {
-                "once": {
-                    "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                    "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                    "dev": true
-                }
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "requires": {
+                "dom-serializer": "0.1.0",
+                "domelementtype": "1.3.0"
             }
         },
         "entities": {
@@ -422,978 +213,346 @@
             "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
             "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
         },
-        "escape-string-regexp": {
-            "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+        "fast-deep-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
             "dev": true
         },
-        "esutils": {
-            "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-            "dev": true
-        },
-        "event-stream": {
-            "version": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-            "dev": true
-        },
-        "execa": {
-            "version": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
-            "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
-            "dev": true
-        },
-        "expand-brackets": {
-            "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-            "dev": true
-        },
-        "expand-range": {
-            "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true
-        },
-        "extend": {
-            "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-            "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-            "dev": true
-        },
-        "extend-shallow": {
-            "version": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-            "dev": true
-        },
-        "extglob": {
-            "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-            "dev": true,
-            "dependencies": {
-                "is-extglob": {
-                    "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                }
-            }
-        },
-        "extsprintf": {
-            "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-            "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-            "dev": true
-        },
-        "fancy-log": {
-            "version": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-            "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
             "dev": true
         },
         "fd-slicer": {
             "version": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU="
-        },
-        "filename-regex": {
-            "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-            "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
-            "dev": true
-        },
-        "fill-range": {
-            "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-            "dev": true
-        },
-        "findup-sync": {
-            "version": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-            "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
-            "dev": true,
-            "dependencies": {
-                "glob": {
-                    "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true
-                }
+            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "requires": {
+                "pend": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
             }
-        },
-        "first-chunk-stream": {
-            "version": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
-        "for-in": {
-            "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-            "dev": true
-        },
-        "for-own": {
-            "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "dev": true
-        },
-        "forever-agent": {
-            "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-            "dev": true
-        },
-        "form-data": {
-            "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-            "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
-            "dev": true
-        },
-        "from": {
-            "version": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-            "dev": true
         },
         "fs.realpath": {
             "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
-        "fstream": {
-            "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-            "dev": true
-        },
-        "generate-function": {
-            "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-            "dev": true
-        },
-        "generate-object-property": {
-            "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-            "dev": true
-        },
-        "get-stream": {
-            "version": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-            "dev": true
-        },
-        "getpass": {
-            "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-            "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
-            "dev": true,
-            "dependencies": {
-                "assert-plus": {
-                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
-            }
-        },
         "glob": {
             "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-            "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg="
+            "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+            "requires": {
+                "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            }
         },
-        "glob-base": {
-            "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+        "global-dirs": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.0.tgz",
+            "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
             "dev": true,
+            "requires": {
+                "ini": "1.3.4"
+            },
             "dependencies": {
-                "glob-parent": {
-                    "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true
-                },
-                "is-extglob": {
-                    "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                "ini": {
+                    "version": "1.3.4",
+                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                    "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
                     "dev": true
                 }
             }
-        },
-        "glob-parent": {
-            "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-            "dev": true
-        },
-        "glob-stream": {
-            "version": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-            "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
-            "dev": true,
-            "dependencies": {
-                "glob": {
-                    "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true
-                },
-                "isarray": {
-                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true
-                }
-            }
-        },
-        "glogg": {
-            "version": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-            "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-            "dev": true
-        },
-        "got": {
-            "version": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-            "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-            "dev": true
-        },
-        "graceful-fs": {
-            "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-            "dev": true
         },
         "graceful-readlink": {
             "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
             "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
         },
-        "growl": {
-            "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-            "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-            "dev": true
-        },
-        "gulp-chmod": {
-            "version": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
-            "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
-            "dev": true
-        },
-        "gulp-filter": {
-            "version": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.0.0.tgz",
-            "integrity": "sha1-z6gZZvtniE8rp1SwZxUpKUKNWbw=",
-            "dev": true
-        },
-        "gulp-gunzip": {
-            "version": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-0.0.3.tgz",
-            "integrity": "sha1-e24HsPWP09QlFcSOrVpj3wVy9i8=",
-            "dev": true,
-            "dependencies": {
-                "clone": {
-                    "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-                    "dev": true
-                },
-                "isarray": {
-                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true
-                }
-            }
-        },
-        "gulp-remote-src": {
-            "version": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.2.tgz",
-            "integrity": "sha1-zrN3DjREMo1hOG+6qrIAvBHNmKg=",
-            "dev": true,
-            "dependencies": {
-                "clone-stats": {
-                    "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-                    "dev": true
-                },
-                "replace-ext": {
-                    "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-                    "dev": true
-                },
-                "request": {
-                    "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-                    "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.1.tgz",
-                    "integrity": "sha1-HDtJMeesTB7+50PzuRp0wJRAe7Y=",
-                    "dev": true
-                }
-            }
-        },
-        "gulp-sourcemaps": {
-            "version": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-            "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-            "dev": true,
-            "dependencies": {
-                "vinyl": {
-                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true
-                }
-            }
-        },
-        "gulp-symdest": {
-            "version": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
-            "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
-            "dev": true
-        },
-        "gulp-untar": {
-            "version": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
-            "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
-            "dev": true
-        },
-        "gulp-util": {
-            "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-            "dev": true,
-            "dependencies": {
-                "minimist": {
-                    "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "object-assign": {
-                    "version": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                    "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-                    "dev": true
-                }
-            }
-        },
-        "gulp-vinyl-zip": {
-            "version": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-1.4.0.tgz",
-            "integrity": "sha1-VjgvLMtXIxuwR4x4c3zNVylzvuE=",
-            "dev": true,
-            "dependencies": {
-                "clone": {
-                    "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-                    "dev": true
-                },
-                "isarray": {
-                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true
-                }
-            }
-        },
-        "gulplog": {
-            "version": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-            "dev": true
-        },
-        "har-schema": {
-            "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-            "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-            "dev": true
-        },
-        "har-validator": {
-            "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-            "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-            "dev": true
-        },
-        "has-ansi": {
-            "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true
-        },
-        "has-flag": {
-            "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-            "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-            "dev": true
-        },
-        "has-gulplog": {
-            "version": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-            "dev": true
-        },
-        "hawk": {
-            "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-            "dev": true
-        },
-        "hoek": {
-            "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+        "he": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
             "dev": true
         },
         "htmlparser2": {
             "version": "3.9.2",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-            "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg="
+            "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+            "requires": {
+                "domelementtype": "1.3.0",
+                "domhandler": "2.4.1",
+                "domutils": "1.5.1",
+                "entities": "1.1.1",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz"
+            }
         },
-        "http-signature": {
-            "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-            "dev": true
-        },
-        "imurmurhash": {
-            "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+        "import-lazy": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
             "dev": true
         },
         "inflight": {
             "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            }
         },
         "inherits": {
             "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
-        "ini": {
-            "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-            "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-            "dev": true
+        "is-installed-globally": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+            "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+            "dev": true,
+            "requires": {
+                "global-dirs": "0.1.0",
+                "is-path-inside": "1.0.0"
+            }
         },
-        "is": {
-            "version": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
-            "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
-            "dev": true
-        },
-        "is-buffer": {
-            "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-            "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-            "dev": true
-        },
-        "is-dotfile": {
-            "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-            "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
-            "dev": true
-        },
-        "is-equal-shallow": {
-            "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true
-        },
-        "is-extendable": {
-            "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-            "dev": true
-        },
-        "is-extglob": {
-            "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
-        },
-        "is-fullwidth-code-point": {
-            "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "dev": true
-        },
-        "is-glob": {
-            "version": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-            "dev": true
-        },
-        "is-my-json-valid": {
-            "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-            "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-            "dev": true
-        },
-        "is-npm": {
-            "version": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-            "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-            "dev": true
-        },
-        "is-number": {
-            "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-            "dev": true
-        },
-        "is-obj": {
-            "version": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-            "dev": true
-        },
-        "is-posix-bracket": {
-            "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
-        },
-        "is-primitive": {
-            "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
-        },
-        "is-property": {
-            "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-            "dev": true
-        },
-        "is-redirect": {
-            "version": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-            "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-            "dev": true
-        },
-        "is-retry-allowed": {
-            "version": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-            "dev": true
-        },
-        "is-stream": {
-            "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true
-        },
-        "is-typedarray": {
-            "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-            "dev": true
-        },
-        "is-utf8": {
-            "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-            "dev": true
-        },
-        "is-valid-glob": {
-            "version": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-            "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
-            "dev": true
+        "is-path-inside": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+            "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+            "dev": true,
+            "requires": {
+                "path-is-inside": "1.0.2"
+            }
         },
         "isarray": {
             "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
-        "isexe": {
-            "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
-        },
-        "isobject": {
-            "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-            "dev": true
-        },
-        "isstream": {
-            "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-            "dev": true
-        },
-        "jade": {
-            "version": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-            "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-            "dev": true,
-            "dependencies": {
-                "commander": {
-                    "version": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-                    "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
-                    "dev": true
-                },
-                "mkdirp": {
-                    "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-                    "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-                    "dev": true
-                }
-            }
-        },
-        "jodid25519": {
-            "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-            "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-            "dev": true,
-            "optional": true
-        },
-        "js-tokens": {
-            "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-            "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
-            "dev": true
-        },
-        "jsbn": {
-            "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "dev": true,
-            "optional": true
-        },
-        "json-schema": {
-            "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-            "dev": true
-        },
-        "json-stable-stringify": {
-            "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-            "dev": true
-        },
-        "json-stringify-safe": {
-            "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-            "dev": true
-        },
-        "json3": {
-            "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-            "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-            "dev": true
-        },
-        "jsonify": {
-            "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-            "dev": true
-        },
-        "jsonpointer": {
-            "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-            "dev": true
-        },
-        "jsprim": {
-            "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-            "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-            "dev": true,
-            "dependencies": {
-                "assert-plus": {
-                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
-            }
-        },
-        "kind-of": {
-            "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-            "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
-            "dev": true
-        },
-        "latest-version": {
-            "version": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-            "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-            "dev": true
-        },
-        "lazy-req": {
-            "version": "https://registry.npmjs.org/lazy-req/-/lazy-req-2.0.0.tgz",
-            "integrity": "sha1-yUUKNj7N2i5vDHATKtTzf48G8rQ=",
-            "dev": true
-        },
-        "lazystream": {
-            "version": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
             "dev": true
         },
         "linkify-it": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
-            "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08="
+            "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
+            "requires": {
+                "uc.micro": "1.0.3"
+            }
         },
         "lodash": {
             "version": "4.17.4",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
             "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         },
-        "lodash._baseassign": {
-            "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-            "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-            "dev": true
-        },
-        "lodash._basecopy": {
-            "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-            "dev": true
-        },
-        "lodash._basecreate": {
-            "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-            "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-            "dev": true
-        },
-        "lodash._basetostring": {
-            "version": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-            "dev": true
-        },
-        "lodash._basevalues": {
-            "version": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-            "dev": true
-        },
-        "lodash._getnative": {
-            "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-            "dev": true
-        },
-        "lodash._isiterateecall": {
-            "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-            "dev": true
-        },
-        "lodash._reescape": {
-            "version": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-            "dev": true
-        },
-        "lodash._reevaluate": {
-            "version": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-            "dev": true
-        },
-        "lodash._reinterpolate": {
-            "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-            "dev": true
-        },
-        "lodash._root": {
-            "version": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-            "dev": true
-        },
-        "lodash.create": {
-            "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-            "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-            "dev": true
-        },
-        "lodash.escape": {
-            "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-            "dev": true
-        },
-        "lodash.isarguments": {
-            "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-            "dev": true
-        },
-        "lodash.isarray": {
-            "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-            "dev": true
-        },
-        "lodash.isequal": {
-            "version": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-            "dev": true
-        },
-        "lodash.keys": {
-            "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "dev": true
-        },
-        "lodash.restparam": {
-            "version": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-            "dev": true
-        },
-        "lodash.template": {
-            "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-            "dev": true
-        },
-        "lodash.templatesettings": {
-            "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-            "dev": true
-        },
-        "lowercase-keys": {
-            "version": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-            "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-            "dev": true
-        },
-        "lru-cache": {
-            "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-            "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-            "dev": true
-        },
-        "map-stream": {
-            "version": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-            "dev": true
+        "make-dir": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+            "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+            "dev": true,
+            "requires": {
+                "pify": "3.0.0"
+            }
         },
         "markdown-it": {
             "version": "8.4.0",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.0.tgz",
-            "integrity": "sha512-tNuOCCfunY5v5uhcO2AUMArvKAyKMygX8tfup/JrgnsDqcCATQsAExBq7o5Ml9iMmO82bk6jYNLj6khcrl0JGA=="
+            "integrity": "sha512-tNuOCCfunY5v5uhcO2AUMArvKAyKMygX8tfup/JrgnsDqcCATQsAExBq7o5Ml9iMmO82bk6jYNLj6khcrl0JGA==",
+            "requires": {
+                "argparse": "1.0.9",
+                "entities": "1.1.1",
+                "linkify-it": "2.0.3",
+                "mdurl": "1.0.1",
+                "uc.micro": "1.0.3"
+            }
         },
         "mdurl": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
             "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
         },
-        "merge-stream": {
-            "version": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-            "dev": true
-        },
-        "micromatch": {
-            "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-            "dev": true,
-            "dependencies": {
-                "is-extglob": {
-                    "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true
-                }
-            }
-        },
         "mime": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
             "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
-        "mime-db": {
-            "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-            "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-            "dev": true
-        },
-        "mime-types": {
-            "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-            "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-            "dev": true
-        },
         "minimatch": {
             "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-            "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q="
-        },
-        "minimist": {
-            "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-            "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-            "dev": true
-        },
-        "mkdirp": {
-            "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
-            "dependencies": {
-                "minimist": {
-                    "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true
-                }
+            "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+            "requires": {
+                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
             }
         },
         "mocha": {
-            "version": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
             "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
             "dev": true,
+            "requires": {
+                "commander": "2.3.0",
+                "debug": "2.2.0",
+                "diff": "1.4.0",
+                "escape-string-regexp": "1.0.2",
+                "glob": "3.2.11",
+                "growl": "1.9.2",
+                "jade": "0.26.3",
+                "mkdirp": "0.5.1",
+                "supports-color": "1.2.0",
+                "to-iso-string": "0.0.2"
+            },
             "dependencies": {
                 "commander": {
-                    "version": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
                     "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
                     "dev": true
                 },
+                "debug": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                    "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "0.7.1"
+                    }
+                },
                 "diff": {
-                    "version": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
                     "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
                     "dev": true
                 },
                 "escape-string-regexp": {
-                    "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
                     "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
                     "dev": true
                 },
                 "glob": {
-                    "version": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                    "version": "3.2.11",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                     "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "minimatch": "0.3.0"
+                    }
+                },
+                "growl": {
+                    "version": "1.9.2",
+                    "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+                    "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
                     "dev": true
                 },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                },
+                "jade": {
+                    "version": "0.26.3",
+                    "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+                    "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+                    "dev": true,
+                    "requires": {
+                        "commander": "0.6.1",
+                        "mkdirp": "0.3.0"
+                    },
+                    "dependencies": {
+                        "commander": {
+                            "version": "0.6.1",
+                            "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+                            "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+                            "dev": true
+                        },
+                        "mkdirp": {
+                            "version": "0.3.0",
+                            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+                            "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+                            "dev": true
+                        }
+                    }
+                },
                 "lru-cache": {
-                    "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                    "version": "2.7.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                     "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
                     "dev": true
                 },
                 "minimatch": {
-                    "version": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                     "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "2.7.3",
+                        "sigmund": "1.0.1"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "0.7.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                    "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+                    "dev": true
+                },
+                "sigmund": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                    "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
                     "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+                    "dev": true
+                },
+                "to-iso-string": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+                    "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
                     "dev": true
                 }
             }
-        },
-        "ms": {
-            "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-            "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-            "dev": true
-        },
-        "multimatch": {
-            "version": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-            "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-            "dev": true
-        },
-        "multipipe": {
-            "version": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-            "dev": true
         },
         "mute-stream": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
             "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
         },
-        "node.extend": {
-            "version": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
-            "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
-            "dev": true
-        },
-        "normalize-path": {
-            "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-            "dev": true
-        },
-        "npm-run-path": {
-            "version": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-            "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-            "dev": true
-        },
         "nth-check": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-            "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ="
-        },
-        "number-is-nan": {
-            "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "dev": true
-        },
-        "oauth-sign": {
-            "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-            "dev": true
-        },
-        "object-assign": {
-            "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
-        },
-        "object.omit": {
-            "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true
+            "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+            "requires": {
+                "boolbase": "1.0.0"
+            }
         },
         "once": {
             "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
-        },
-        "optimist": {
-            "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-            "dev": true
-        },
-        "ordered-read-streams": {
-            "version": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-            "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-            "dev": true
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            }
         },
         "os-homedir": {
             "version": "1.0.2",
@@ -1408,235 +567,520 @@
         "osenv": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-            "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ="
-        },
-        "package-json": {
-            "version": "https://registry.npmjs.org/package-json/-/package-json-4.0.0.tgz",
-            "integrity": "sha1-88nchzj1tZME1U0s+z+R0I/deZg=",
-            "dev": true
-        },
-        "parse-glob": {
-            "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true,
-            "dependencies": {
-                "is-extglob": {
-                    "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true
-                }
+            "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+            "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
             }
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
         },
         "parse5": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz",
-            "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA="
-        },
-        "path-dirname": {
-            "version": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-            "dev": true
+            "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
+            "requires": {
+                "@types/node": "6.0.90"
+            }
         },
         "path-is-absolute": {
             "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
-        "path-key": {
-            "version": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-            "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
-            "dev": true
-        },
-        "path-parse": {
-            "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-            "dev": true
-        },
-        "pause-stream": {
-            "version": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
             "dev": true
         },
         "pend": {
             "version": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
             "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
         },
-        "performance-now": {
-            "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-            "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-            "dev": true
-        },
-        "pinkie": {
-            "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true
-        },
-        "prepend-http": {
-            "version": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-            "dev": true
-        },
-        "preserve": {
-            "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+        "pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
             "dev": true
         },
         "process-nextick-args": {
             "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
-        "pseudomap": {
-            "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-            "dev": true
-        },
-        "punycode": {
-            "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-            "dev": true
-        },
         "q": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
             "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
         },
-        "qs": {
-            "version": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+        "querystringify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+            "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
             "dev": true
-        },
-        "queue": {
-            "version": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
-            "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
-            "dev": true
-        },
-        "randomatic": {
-            "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-            "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-            "dev": true
-        },
-        "rc": {
-            "version": "https://registry.npmjs.org/rc/-/rc-1.2.0.tgz",
-            "integrity": "sha1-x96XO3tGKXwEE2ay/T0jY7FpfGY=",
-            "dev": true,
-            "dependencies": {
-                "minimist": {
-                    "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
-            }
         },
         "read": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ="
+            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+            "requires": {
+                "mute-stream": "0.0.7"
+            }
         },
         "readable-stream": {
             "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
-            "integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY="
+            "integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY=",
+            "requires": {
+                "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            }
         },
-        "regex-cache": {
-            "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-            "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-            "dev": true
+        "request": {
+            "version": "2.83.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+                    "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+                    "dev": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "fast-deep-equal": "1.0.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1"
+                    }
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                    "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                    "dev": true
+                },
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                    "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+                    "dev": true
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+                    "dev": true
+                },
+                "aws4": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                    "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+                    "dev": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                    "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "boom": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+                    "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "4.2.0"
+                    }
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+                    "dev": true
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                    "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+                    "dev": true
+                },
+                "combined-stream": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                    "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                    "dev": true
+                },
+                "cryptiles": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+                    "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+                    "dev": true,
+                    "requires": {
+                        "boom": "5.2.0"
+                    },
+                    "dependencies": {
+                        "boom": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                            "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                            "dev": true,
+                            "requires": {
+                                "hoek": "4.2.0"
+                            }
+                        }
+                    }
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                    "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    }
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                    "dev": true
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                    "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "extend": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                    "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+                    "dev": true
+                },
+                "extsprintf": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+                    "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+                    "dev": true
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                    "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                    "dev": true
+                },
+                "form-data": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+                    "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.17"
+                    }
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                    "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    }
+                },
+                "har-schema": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+                    "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+                    "dev": true
+                },
+                "har-validator": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+                    "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "5.3.0",
+                        "har-schema": "2.0.0"
+                    }
+                },
+                "hawk": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+                    "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+                    "dev": true,
+                    "requires": {
+                        "boom": "4.3.1",
+                        "cryptiles": "3.1.2",
+                        "hoek": "4.2.0",
+                        "sntp": "2.1.0"
+                    }
+                },
+                "hoek": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+                    "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.13.1"
+                    }
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                    "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+                    "dev": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                    "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                    "dev": true
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                    "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+                    "dev": true,
+                    "optional": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                    "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+                    "dev": true
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                    "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                    "dev": true
+                },
+                "jsprim": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+                    "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.3.0",
+                        "json-schema": "0.2.3",
+                        "verror": "1.10.0"
+                    }
+                },
+                "mime-db": {
+                    "version": "1.30.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+                    "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.17",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+                    "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.30.0"
+                    }
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                    "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+                    "dev": true
+                },
+                "performance-now": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+                    "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.5.1",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+                    "dev": true
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+                    "dev": true
+                },
+                "sntp": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+                    "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "4.2.0"
+                    }
+                },
+                "sshpk": {
+                    "version": "1.13.1",
+                    "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                    "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+                    "dev": true,
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "stringstream": {
+                    "version": "0.0.5",
+                    "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                    "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+                    "dev": true
+                },
+                "tough-cookie": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+                    "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+                    "dev": true,
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                    "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+                    "dev": true,
+                    "optional": true
+                },
+                "uuid": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+                    "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+                    "dev": true
+                },
+                "verror": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                    "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "extsprintf": "1.3.0"
+                    }
+                }
+            }
         },
-        "registry-auth-token": {
-            "version": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz",
-            "integrity": "sha1-mXwIJW4MeZmDe5DpRNs52KeQJ2s=",
-            "dev": true
-        },
-        "registry-url": {
-            "version": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-            "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-            "dev": true
-        },
-        "remove-trailing-separator": {
-            "version": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
-            "integrity": "sha1-YV67lq9VlVLUv0BXyENtSGq2PMQ=",
-            "dev": true
-        },
-        "repeat-element": {
-            "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-            "dev": true
-        },
-        "repeat-string": {
-            "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
-        },
-        "replace-ext": {
-            "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-            "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-            "dev": true
-        },
-        "resolve": {
-            "version": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-            "integrity": "sha1-HwRCyeDLuBNuh7kwX5MvRsfygjU=",
-            "dev": true
-        },
-        "rimraf": {
-            "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-            "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-            "dev": true
-        },
-        "safe-buffer": {
-            "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-            "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
             "dev": true
         },
         "semver": {
             "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
             "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
         },
-        "semver-diff": {
-            "version": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-            "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
         },
-        "sigmund": {
-            "version": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-            "dev": true
-        },
-        "slide": {
-            "version": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-            "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-            "dev": true
-        },
-        "sntp": {
-            "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-            "dev": true
-        },
-        "source-map": {
-            "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-            "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-            "dev": true
-        },
-        "source-map-support": {
-            "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
-            "integrity": "sha1-nURjdyWYuGJxtPUj9sH04Cp9au8=",
-            "dev": true
-        },
-        "sparkles": {
-            "version": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-            "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
-            "dev": true
-        },
-        "split": {
-            "version": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
         },
         "sprintf-js": {
@@ -1644,183 +1088,817 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
-        "sshpk": {
-            "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
-            "integrity": "sha1-LY1eu0pvqyj/ujf6YqkPSj6lnXc=",
-            "dev": true,
-            "dependencies": {
-                "assert-plus": {
-                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
-            }
-        },
-        "stat-mode": {
-            "version": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
-            "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
-            "dev": true
-        },
-        "stream-combiner": {
-            "version": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-            "dev": true
-        },
-        "stream-shift": {
-            "version": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-            "dev": true
-        },
-        "streamfilter": {
-            "version": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz",
-            "integrity": "sha1-h1BxEb644phFFxe1Ec/tjwAqv1M=",
-            "dev": true
-        },
-        "streamifier": {
-            "version": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
-            "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
-            "dev": true
-        },
         "string_decoder": {
             "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
             "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
-        "string-width": {
-            "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-            "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-            "dev": true,
-            "dependencies": {
-                "is-fullwidth-code-point": {
-                    "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                }
-            }
-        },
-        "stringstream": {
-            "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-            "dev": true
-        },
-        "strip-ansi": {
-            "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "dev": true
-        },
-        "strip-bom": {
-            "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true
-        },
-        "strip-bom-stream": {
-            "version": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-            "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-            "dev": true
-        },
-        "strip-eof": {
-            "version": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-            "dev": true
-        },
-        "strip-json-comments": {
-            "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "dev": true
-        },
-        "supports-color": {
-            "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-            "dev": true
-        },
-        "tar": {
-            "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-            "dev": true
-        },
-        "term-size": {
-            "version": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
-            "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
-            "dev": true
-        },
-        "through": {
-            "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-            "dev": true
-        },
-        "through2": {
-            "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-            "dev": true
-        },
-        "through2-filter": {
-            "version": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-            "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-            "dev": true
-        },
-        "time-stamp": {
-            "version": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
-            "integrity": "sha1-n0vSNVnJNllm8zAtu6KwfGuZsVE=",
-            "dev": true
-        },
-        "timed-out": {
-            "version": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-            "dev": true
-        },
         "tmp": {
             "version": "0.0.29",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-            "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA="
-        },
-        "to-absolute-glob": {
-            "version": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-            "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-            "dev": true
-        },
-        "to-iso-string": {
-            "version": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-            "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
-            "dev": true
-        },
-        "tough-cookie": {
-            "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-            "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-            "dev": true
+            "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+            "requires": {
+                "os-tmpdir": "1.0.2"
+            }
         },
         "tslint": {
-            "version": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
             "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
-            "dev": true
-        },
-        "tsutils": {
-            "version": "https://registry.npmjs.org/tsutils/-/tsutils-1.4.0.tgz",
-            "integrity": "sha1-hPioPfmWfTW/H/OqSMczlZPWThk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "6.26.0",
+                "colors": "1.1.2",
+                "diff": "3.4.0",
+                "findup-sync": "0.3.0",
+                "glob": "7.1.2",
+                "optimist": "0.6.1",
+                "resolve": "1.5.0",
+                "tsutils": "1.9.1",
+                "update-notifier": "2.3.0"
+            },
+            "dependencies": {
+                "ansi-align": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+                    "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "2.1.1"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "babel-code-frame": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+                    "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "esutils": "2.0.2",
+                        "js-tokens": "3.0.2"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "dev": true
+                },
+                "boxen": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz",
+                    "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-align": "2.0.0",
+                        "camelcase": "4.1.0",
+                        "chalk": "2.3.0",
+                        "cli-boxes": "1.0.0",
+                        "string-width": "2.1.1",
+                        "term-size": "1.2.0",
+                        "widest-line": "1.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-styles": {
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                            "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                            "dev": true,
+                            "requires": {
+                                "color-convert": "1.9.1"
+                            }
+                        },
+                        "chalk": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+                            "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "3.2.0",
+                                "escape-string-regexp": "1.0.5",
+                                "supports-color": "4.5.0"
+                            }
+                        },
+                        "supports-color": {
+                            "version": "4.5.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+                            "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "2.0.0"
+                            }
+                        }
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.8",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                    "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                },
+                "capture-stack-trace": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+                    "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "cli-boxes": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+                    "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+                    "dev": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                    "dev": true
+                },
+                "colors": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+                    "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+                    "dev": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                    "dev": true
+                },
+                "configstore": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+                    "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+                    "dev": true,
+                    "requires": {
+                        "dot-prop": "4.2.0",
+                        "graceful-fs": "4.1.11",
+                        "make-dir": "1.1.0",
+                        "unique-string": "1.0.0",
+                        "write-file-atomic": "2.3.0",
+                        "xdg-basedir": "3.0.0"
+                    }
+                },
+                "create-error-class": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+                    "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+                    "dev": true,
+                    "requires": {
+                        "capture-stack-trace": "1.0.0"
+                    }
+                },
+                "crypto-random-string": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+                    "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+                    "dev": true
+                },
+                "deep-extend": {
+                    "version": "0.4.2",
+                    "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                    "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+                    "dev": true
+                },
+                "diff": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+                    "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+                    "dev": true
+                },
+                "dot-prop": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+                    "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-obj": "1.0.1"
+                    }
+                },
+                "duplexer3": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+                    "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                },
+                "esutils": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                    "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+                    "dev": true
+                },
+                "execa": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                    "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                    }
+                },
+                "findup-sync": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+                    "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+                    "dev": true,
+                    "requires": {
+                        "glob": "5.0.15"
+                    },
+                    "dependencies": {
+                        "glob": {
+                            "version": "5.0.15",
+                            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                            "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                            "dev": true,
+                            "requires": {
+                                "inflight": "1.0.6",
+                                "inherits": "2.0.3",
+                                "minimatch": "3.0.4",
+                                "once": "1.4.0",
+                                "path-is-absolute": "1.0.1"
+                            }
+                        }
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                    "dev": true
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+                    "dev": true
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "got": {
+                    "version": "6.7.1",
+                    "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+                    "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+                    "dev": true,
+                    "requires": {
+                        "create-error-class": "3.0.2",
+                        "duplexer3": "0.1.4",
+                        "get-stream": "3.0.0",
+                        "is-redirect": "1.0.0",
+                        "is-retry-allowed": "1.1.0",
+                        "is-stream": "1.1.0",
+                        "lowercase-keys": "1.0.0",
+                        "safe-buffer": "5.1.1",
+                        "timed-out": "4.0.1",
+                        "unzip-response": "2.0.1",
+                        "url-parse-lax": "1.0.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                    "dev": true
+                },
+                "has-ansi": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                    "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+                    "dev": true
+                },
+                "imurmurhash": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                    "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+                    "dev": true
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.4",
+                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                    "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "is-npm": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+                    "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+                    "dev": true
+                },
+                "is-obj": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+                    "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+                    "dev": true
+                },
+                "is-redirect": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+                    "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+                    "dev": true
+                },
+                "is-retry-allowed": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+                    "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+                    "dev": true
+                },
+                "latest-version": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+                    "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+                    "dev": true,
+                    "requires": {
+                        "package-json": "4.0.1"
+                    }
+                },
+                "lowercase-keys": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                    "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.10",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                    "dev": true
+                },
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                    "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "2.0.1"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                    "dev": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "optimist": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                    "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.10",
+                        "wordwrap": "0.0.3"
+                    }
+                },
+                "package-json": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+                    "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+                    "dev": true,
+                    "requires": {
+                        "got": "6.7.1",
+                        "registry-auth-token": "3.3.1",
+                        "registry-url": "3.1.0",
+                        "semver": "5.4.1"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+                    "dev": true
+                },
+                "path-parse": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+                    "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+                    "dev": true
+                },
+                "prepend-http": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+                    "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+                    "dev": true
+                },
+                "rc": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+                    "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+                    "dev": true,
+                    "requires": {
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                            "dev": true
+                        }
+                    }
+                },
+                "registry-auth-token": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+                    "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+                    "dev": true,
+                    "requires": {
+                        "rc": "1.2.2",
+                        "safe-buffer": "5.1.1"
+                    }
+                },
+                "registry-url": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+                    "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+                    "dev": true,
+                    "requires": {
+                        "rc": "1.2.2"
+                    }
+                },
+                "resolve": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+                    "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "1.0.5"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.4.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+                    "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+                    "dev": true
+                },
+                "semver-diff": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+                    "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+                    "dev": true,
+                    "requires": {
+                        "semver": "5.4.1"
+                    }
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "3.0.0"
+                            }
+                        }
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-eof": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                    "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+                    "dev": true
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                },
+                "term-size": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+                    "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+                    "dev": true,
+                    "requires": {
+                        "execa": "0.7.0"
+                    }
+                },
+                "timed-out": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+                    "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+                    "dev": true
+                },
+                "tsutils": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
+                    "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=",
+                    "dev": true
+                },
+                "unique-string": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+                    "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+                    "dev": true,
+                    "requires": {
+                        "crypto-random-string": "1.0.0"
+                    }
+                },
+                "unzip-response": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+                    "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+                    "dev": true
+                },
+                "update-notifier": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+                    "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+                    "dev": true,
+                    "requires": {
+                        "boxen": "1.2.2",
+                        "chalk": "2.3.0",
+                        "configstore": "3.1.1",
+                        "import-lazy": "2.1.0",
+                        "is-installed-globally": "0.1.0",
+                        "is-npm": "1.0.0",
+                        "latest-version": "3.1.0",
+                        "semver-diff": "2.1.0",
+                        "xdg-basedir": "3.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-styles": {
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                            "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                            "dev": true,
+                            "requires": {
+                                "color-convert": "1.9.1"
+                            }
+                        },
+                        "chalk": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+                            "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "3.2.0",
+                                "escape-string-regexp": "1.0.5",
+                                "supports-color": "4.5.0"
+                            }
+                        },
+                        "supports-color": {
+                            "version": "4.5.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+                            "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "2.0.0"
+                            }
+                        }
+                    }
+                },
+                "url-parse-lax": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                    "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+                    "dev": true,
+                    "requires": {
+                        "prepend-http": "1.0.4"
+                    }
+                },
+                "widest-line": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+                    "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    },
+                    "dependencies": {
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                            "dev": true,
+                            "requires": {
+                                "number-is-nan": "1.0.1"
+                            }
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
+                            }
+                        }
+                    }
+                },
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                    "dev": true
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                    "dev": true
+                },
+                "write-file-atomic": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+                    "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "imurmurhash": "0.1.4",
+                        "signal-exit": "3.0.2"
+                    }
+                },
+                "xdg-basedir": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+                    "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+                    "dev": true
+                }
+            }
         },
         "tunnel": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
             "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
         },
-        "tunnel-agent": {
-            "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-            "dev": true
-        },
-        "tweetnacl": {
-            "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "dev": true,
-            "optional": true
-        },
         "typed-rest-client": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
-            "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI="
+            "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+            "requires": {
+                "tunnel": "0.0.4",
+                "underscore": "1.8.3"
+            }
         },
         "typescript": {
-            "version": "https://registry.npmjs.org/typescript/-/typescript-2.2.2.tgz",
-            "integrity": "sha1-YGAiUIR5tV/6NotY/uljoD39eww=",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
+            "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
             "dev": true
         },
         "uc.micro": {
@@ -1833,221 +1911,2391 @@
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
             "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
         },
-        "unique-stream": {
-            "version": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-            "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-            "dev": true
-        },
-        "unique-string": {
-            "version": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-            "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-            "dev": true
-        },
-        "unzip-response": {
-            "version": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-            "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-            "dev": true
-        },
-        "update-notifier": {
-            "version": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.1.0.tgz",
-            "integrity": "sha1-7AweU1NrdmR6JLd8uDlm2TFRI9k=",
-            "dev": true
-        },
         "url-join": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
             "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
         },
-        "url-parse-lax": {
-            "version": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-            "dev": true
+        "url-parse": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
+            "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+            "dev": true,
+            "requires": {
+                "querystringify": "1.0.0",
+                "requires-port": "1.0.0"
+            }
         },
         "util-deprecate": {
             "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
-        "uuid": {
-            "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-            "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-            "dev": true
-        },
-        "vali-date": {
-            "version": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
-            "dev": true
-        },
-        "verror": {
-            "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-            "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-            "dev": true
-        },
-        "vinyl": {
-            "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-            "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-            "dev": true
-        },
-        "vinyl-fs": {
-            "version": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-            "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-            "dev": true,
-            "dependencies": {
-                "vinyl": {
-                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true
-                }
-            }
-        },
-        "vinyl-source-stream": {
-            "version": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
-            "integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
-            "dev": true,
-            "dependencies": {
-                "clone": {
-                    "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-                    "dev": true
-                },
-                "isarray": {
-                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true
-                }
-            }
-        },
         "vsce": {
             "version": "1.31.1",
             "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.31.1.tgz",
-            "integrity": "sha1-3F4eDkaZSdkJ/GshP4S1YqL06a8="
+            "integrity": "sha1-3F4eDkaZSdkJ/GshP4S1YqL06a8=",
+            "requires": {
+                "cheerio": "1.0.0-rc.2",
+                "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                "denodeify": "1.2.1",
+                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                "lodash": "4.17.4",
+                "markdown-it": "8.4.0",
+                "mime": "1.4.1",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                "osenv": "0.1.4",
+                "read": "1.0.7",
+                "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                "tmp": "0.0.29",
+                "url-join": "1.1.0",
+                "vso-node-api": "6.1.2-preview",
+                "yauzl": "https://registry.npmjs.org/yauzl/-/yauzl-2.7.0.tgz",
+                "yazl": "https://registry.npmjs.org/yazl/-/yazl-2.4.2.tgz"
+            }
         },
         "vscode": {
-            "version": "https://registry.npmjs.org/vscode/-/vscode-1.1.0.tgz",
-            "integrity": "sha1-sEwjmbbsdoE1yWiOeHPXduKNy5U=",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.6.tgz",
+            "integrity": "sha1-Ru0a+iwbnWifY5TI8WvR1xkPdfs=",
             "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "gulp-chmod": "2.0.0",
+                "gulp-filter": "5.0.1",
+                "gulp-gunzip": "1.0.0",
+                "gulp-remote-src": "0.4.3",
+                "gulp-symdest": "1.1.0",
+                "gulp-untar": "0.0.6",
+                "gulp-vinyl-zip": "2.1.0",
+                "mocha": "4.0.1",
+                "request": "2.83.0",
+                "semver": "5.4.1",
+                "source-map-support": "0.5.0",
+                "url-parse": "1.2.0",
+                "vinyl-source-stream": "1.1.0"
+            },
             "dependencies": {
-                "caseless": {
-                    "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                     "dev": true
                 },
-                "diff": {
-                    "version": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-                    "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
                     "dev": true
                 },
-                "har-validator": {
-                    "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-                    "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-                    "dev": true
-                },
-                "mocha": {
-                    "version": "https://registry.npmjs.org/mocha/-/mocha-3.2.0.tgz",
-                    "integrity": "sha1-fcT0XlCIB1FxpoiWgU5q6et6heM=",
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0"
+                    }
+                },
+                "arr-flatten": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+                    "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+                    "dev": true
+                },
+                "array-differ": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+                    "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+                    "dev": true
+                },
+                "array-union": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                    "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                    "dev": true,
+                    "requires": {
+                        "array-uniq": "1.0.3"
+                    }
+                },
+                "array-uniq": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+                    "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+                    "dev": true
+                },
+                "arrify": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                    "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+                    "dev": true
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                    "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                    "dev": true
+                },
+                "assert-plus": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                    "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                    "dev": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                    "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+                    "dev": true
+                },
+                "aws-sign2": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                    "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+                    "dev": true
+                },
+                "aws4": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                    "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+                    "dev": true
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "dev": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                    "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "beeper": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+                    "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+                    "dev": true
+                },
+                "boom": {
+                    "version": "2.10.1",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                    "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.8",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                    "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "1.8.5",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                    "dev": true,
+                    "requires": {
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
+                    }
+                },
+                "browser-stdout": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+                    "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+                    "dev": true
+                },
+                "buffer-crc32": {
+                    "version": "0.2.13",
+                    "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+                    "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+                    "dev": true
+                },
+                "caseless": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                    "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "clone": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+                    "dev": true
+                },
+                "clone-buffer": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+                    "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                    "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+                    "dev": true
+                },
+                "cloneable-readable": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+                    "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "process-nextick-args": "1.0.7",
+                        "through2": "2.0.3"
+                    }
+                },
+                "combined-stream": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                    "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                },
+                "commander": {
+                    "version": "2.11.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+                    "dev": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                    "dev": true
+                },
+                "convert-source-map": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+                    "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+                    "dev": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                    "dev": true
+                },
+                "cryptiles": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                    "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1"
+                    }
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                    "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
                     "dependencies": {
-                        "glob": {
-                            "version": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-                            "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                             "dev": true
                         }
                     }
                 },
-                "qs": {
-                    "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                    "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+                "dateformat": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+                    "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
                     "dev": true
                 },
-                "request": {
-                    "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-                    "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "deep-assign": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+                    "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
+                    "dev": true,
+                    "requires": {
+                        "is-obj": "1.0.1"
+                    }
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                     "dev": true
+                },
+                "diff": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+                    "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+                    "dev": true
+                },
+                "duplexer": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+                    "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+                    "dev": true
+                },
+                "duplexer2": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                    "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.1.14"
+                    },
+                    "dependencies": {
+                        "isarray": {
+                            "version": "0.0.1",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                            "dev": true
+                        },
+                        "readable-stream": {
+                            "version": "1.1.14",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                            "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "0.0.1",
+                                "string_decoder": "0.10.31"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "0.10.31",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                            "dev": true
+                        }
+                    }
+                },
+                "duplexify": {
+                    "version": "3.5.1",
+                    "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+                    "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "1.4.0",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.3",
+                        "stream-shift": "1.0.0"
+                    }
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                    "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "end-of-stream": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+                    "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                },
+                "event-stream": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+                    "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+                    "dev": true,
+                    "requires": {
+                        "duplexer": "0.1.1",
+                        "from": "0.1.7",
+                        "map-stream": "0.1.0",
+                        "pause-stream": "0.0.11",
+                        "split": "0.3.3",
+                        "stream-combiner": "0.0.4",
+                        "through": "2.3.8"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                    "dev": true,
+                    "requires": {
+                        "is-posix-bracket": "0.1.1"
+                    }
+                },
+                "expand-range": {
+                    "version": "1.8.2",
+                    "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                    "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "2.2.3"
+                    }
+                },
+                "extend": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                    "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+                    "dev": true
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "extglob": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    },
+                    "dependencies": {
+                        "is-extglob": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                            "dev": true
+                        }
+                    }
+                },
+                "extsprintf": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+                    "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+                    "dev": true
+                },
+                "fancy-log": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+                    "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "time-stamp": "1.1.0"
+                    }
+                },
+                "fd-slicer": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+                    "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+                    "dev": true,
+                    "requires": {
+                        "pend": "1.2.0"
+                    }
+                },
+                "filename-regex": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+                    "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "2.2.3",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                    "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "1.1.7",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.6.1"
+                    }
+                },
+                "first-chunk-stream": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+                    "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+                    "dev": true
+                },
+                "for-in": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+                    "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+                    "dev": true
+                },
+                "for-own": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                    "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "1.0.2"
+                    }
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                    "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                    "dev": true
+                },
+                "form-data": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                    "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.17"
+                    }
+                },
+                "from": {
+                    "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+                    "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+                    "dev": true
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                    "dev": true
+                },
+                "fstream": {
+                    "version": "1.0.11",
+                    "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                    "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.2"
+                    }
+                },
+                "generate-function": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                    "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                    "dev": true
+                },
+                "generate-object-property": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                    "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                    "dev": true,
+                    "requires": {
+                        "is-property": "1.0.2"
+                    }
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                    "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "glob-base": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                    "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+                    "dev": true,
+                    "requires": {
+                        "glob-parent": "2.0.0",
+                        "is-glob": "2.0.1"
+                    },
+                    "dependencies": {
+                        "glob-parent": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                            "dev": true,
+                            "requires": {
+                                "is-glob": "2.0.1"
+                            }
+                        },
+                        "is-extglob": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                            "dev": true
+                        },
+                        "is-glob": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                            "dev": true,
+                            "requires": {
+                                "is-extglob": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "glob-parent": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "3.1.0",
+                        "path-dirname": "1.0.2"
+                    }
+                },
+                "glob-stream": {
+                    "version": "5.3.5",
+                    "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+                    "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+                    "dev": true,
+                    "requires": {
+                        "extend": "3.0.1",
+                        "glob": "5.0.15",
+                        "glob-parent": "3.1.0",
+                        "micromatch": "2.3.11",
+                        "ordered-read-streams": "0.3.0",
+                        "through2": "0.6.5",
+                        "to-absolute-glob": "0.1.1",
+                        "unique-stream": "2.2.1"
+                    },
+                    "dependencies": {
+                        "glob": {
+                            "version": "5.0.15",
+                            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                            "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                            "dev": true,
+                            "requires": {
+                                "inflight": "1.0.6",
+                                "inherits": "2.0.3",
+                                "minimatch": "3.0.4",
+                                "once": "1.4.0",
+                                "path-is-absolute": "1.0.1"
+                            }
+                        },
+                        "isarray": {
+                            "version": "0.0.1",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                            "dev": true
+                        },
+                        "readable-stream": {
+                            "version": "1.0.34",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "0.0.1",
+                                "string_decoder": "0.10.31"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "0.10.31",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                            "dev": true
+                        },
+                        "through2": {
+                            "version": "0.6.5",
+                            "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                            "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                            "dev": true,
+                            "requires": {
+                                "readable-stream": "1.0.34",
+                                "xtend": "4.0.1"
+                            }
+                        }
+                    }
+                },
+                "glogg": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+                    "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+                    "dev": true,
+                    "requires": {
+                        "sparkles": "1.0.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                    "dev": true
+                },
+                "growl": {
+                    "version": "1.10.3",
+                    "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+                    "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+                    "dev": true
+                },
+                "gulp-chmod": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
+                    "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
+                    "dev": true,
+                    "requires": {
+                        "deep-assign": "1.0.0",
+                        "stat-mode": "0.2.2",
+                        "through2": "2.0.3"
+                    }
+                },
+                "gulp-filter": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.0.1.tgz",
+                    "integrity": "sha512-5olRzAhFdXB2klCu1lnazP65aO9YdA/5WfC9VdInIc8PrUeDIoZfaA3Edb0yUBGhVdHv4eHKL9Fg5tUoEJ9z5A==",
+                    "dev": true,
+                    "requires": {
+                        "gulp-util": "3.0.8",
+                        "multimatch": "2.1.0",
+                        "streamfilter": "1.0.5"
+                    }
+                },
+                "gulp-gunzip": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
+                    "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
+                    "dev": true,
+                    "requires": {
+                        "through2": "0.6.5",
+                        "vinyl": "0.4.6"
+                    },
+                    "dependencies": {
+                        "clone": {
+                            "version": "0.2.0",
+                            "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                            "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                            "dev": true
+                        },
+                        "isarray": {
+                            "version": "0.0.1",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                            "dev": true
+                        },
+                        "readable-stream": {
+                            "version": "1.0.34",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "0.0.1",
+                                "string_decoder": "0.10.31"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "0.10.31",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                            "dev": true
+                        },
+                        "through2": {
+                            "version": "0.6.5",
+                            "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                            "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                            "dev": true,
+                            "requires": {
+                                "readable-stream": "1.0.34",
+                                "xtend": "4.0.1"
+                            }
+                        },
+                        "vinyl": {
+                            "version": "0.4.6",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                            "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                            "dev": true,
+                            "requires": {
+                                "clone": "0.2.0",
+                                "clone-stats": "0.0.1"
+                            }
+                        }
+                    }
+                },
+                "gulp-remote-src": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.3.tgz",
+                    "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
+                    "dev": true,
+                    "requires": {
+                        "event-stream": "3.3.4",
+                        "node.extend": "1.1.6",
+                        "request": "2.79.0",
+                        "through2": "2.0.3",
+                        "vinyl": "2.0.2"
+                    },
+                    "dependencies": {
+                        "clone-stats": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                            "dev": true
+                        },
+                        "replace-ext": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                            "dev": true
+                        },
+                        "request": {
+                            "version": "2.79.0",
+                            "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+                            "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+                            "dev": true,
+                            "requires": {
+                                "aws-sign2": "0.6.0",
+                                "aws4": "1.6.0",
+                                "caseless": "0.11.0",
+                                "combined-stream": "1.0.5",
+                                "extend": "3.0.1",
+                                "forever-agent": "0.6.1",
+                                "form-data": "2.1.4",
+                                "har-validator": "2.0.6",
+                                "hawk": "3.1.3",
+                                "http-signature": "1.1.1",
+                                "is-typedarray": "1.0.0",
+                                "isstream": "0.1.2",
+                                "json-stringify-safe": "5.0.1",
+                                "mime-types": "2.1.17",
+                                "oauth-sign": "0.8.2",
+                                "qs": "6.3.2",
+                                "stringstream": "0.0.5",
+                                "tough-cookie": "2.3.3",
+                                "tunnel-agent": "0.4.3",
+                                "uuid": "3.1.0"
+                            }
+                        },
+                        "vinyl": {
+                            "version": "2.0.2",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
+                            "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+                            "dev": true,
+                            "requires": {
+                                "clone": "1.0.3",
+                                "clone-buffer": "1.0.0",
+                                "clone-stats": "1.0.0",
+                                "cloneable-readable": "1.0.0",
+                                "is-stream": "1.1.0",
+                                "remove-trailing-separator": "1.1.0",
+                                "replace-ext": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "gulp-sourcemaps": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+                    "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+                    "dev": true,
+                    "requires": {
+                        "convert-source-map": "1.5.0",
+                        "graceful-fs": "4.1.11",
+                        "strip-bom": "2.0.0",
+                        "through2": "2.0.3",
+                        "vinyl": "1.2.0"
+                    },
+                    "dependencies": {
+                        "vinyl": {
+                            "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                            "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                            "dev": true,
+                            "requires": {
+                                "clone": "1.0.3",
+                                "clone-stats": "0.0.1",
+                                "replace-ext": "0.0.1"
+                            }
+                        }
+                    }
+                },
+                "gulp-symdest": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
+                    "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
+                    "dev": true,
+                    "requires": {
+                        "event-stream": "3.3.4",
+                        "mkdirp": "0.5.1",
+                        "queue": "3.1.0",
+                        "vinyl-fs": "2.4.4"
+                    }
+                },
+                "gulp-untar": {
+                    "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
+                    "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
+                    "dev": true,
+                    "requires": {
+                        "event-stream": "3.3.4",
+                        "gulp-util": "3.0.8",
+                        "streamifier": "0.1.1",
+                        "tar": "2.2.1",
+                        "through2": "2.0.3"
+                    }
+                },
+                "gulp-util": {
+                    "version": "3.0.8",
+                    "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+                    "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+                    "dev": true,
+                    "requires": {
+                        "array-differ": "1.0.0",
+                        "array-uniq": "1.0.3",
+                        "beeper": "1.1.1",
+                        "chalk": "1.1.3",
+                        "dateformat": "2.2.0",
+                        "fancy-log": "1.3.0",
+                        "gulplog": "1.0.0",
+                        "has-gulplog": "0.1.0",
+                        "lodash._reescape": "3.0.0",
+                        "lodash._reevaluate": "3.0.0",
+                        "lodash._reinterpolate": "3.0.0",
+                        "lodash.template": "3.6.2",
+                        "minimist": "1.2.0",
+                        "multipipe": "0.1.2",
+                        "object-assign": "3.0.0",
+                        "replace-ext": "0.0.1",
+                        "through2": "2.0.3",
+                        "vinyl": "0.5.3"
+                    }
+                },
+                "gulp-vinyl-zip": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
+                    "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
+                    "dev": true,
+                    "requires": {
+                        "event-stream": "3.3.4",
+                        "queue": "4.4.2",
+                        "through2": "2.0.3",
+                        "vinyl": "2.1.0",
+                        "vinyl-fs": "2.4.4",
+                        "yauzl": "2.9.1",
+                        "yazl": "2.4.3"
+                    },
+                    "dependencies": {
+                        "clone": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+                            "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+                            "dev": true
+                        },
+                        "clone-stats": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                            "dev": true
+                        },
+                        "queue": {
+                            "version": "4.4.2",
+                            "resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
+                            "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
+                            "dev": true,
+                            "requires": {
+                                "inherits": "2.0.3"
+                            }
+                        },
+                        "replace-ext": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                            "dev": true
+                        },
+                        "vinyl": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+                            "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+                            "dev": true,
+                            "requires": {
+                                "clone": "2.1.1",
+                                "clone-buffer": "1.0.0",
+                                "clone-stats": "1.0.0",
+                                "cloneable-readable": "1.0.0",
+                                "remove-trailing-separator": "1.1.0",
+                                "replace-ext": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "gulplog": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+                    "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+                    "dev": true,
+                    "requires": {
+                        "glogg": "1.0.0"
+                    }
+                },
+                "har-validator": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                    "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "commander": "2.11.0",
+                        "is-my-json-valid": "2.16.1",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "has-ansi": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                    "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+                    "dev": true
+                },
+                "has-gulplog": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+                    "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+                    "dev": true,
+                    "requires": {
+                        "sparkles": "1.0.0"
+                    }
+                },
+                "hawk": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                    "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                    }
+                },
+                "hoek": {
+                    "version": "2.16.3",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                    "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.13.1"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                },
+                "is": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+                    "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
+                    "dev": true
+                },
+                "is-buffer": {
+                    "version": "1.1.6",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                    "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+                    "dev": true
+                },
+                "is-dotfile": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+                    "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+                    "dev": true
+                },
+                "is-equal-shallow": {
+                    "version": "0.1.3",
+                    "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                    "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-primitive": "2.0.0"
+                    }
+                },
+                "is-extendable": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                    "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+                    "dev": true
+                },
+                "is-extglob": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "2.1.1"
+                    }
+                },
+                "is-my-json-valid": {
+                    "version": "2.16.1",
+                    "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+                    "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+                    "dev": true,
+                    "requires": {
+                        "generate-function": "2.0.0",
+                        "generate-object-property": "1.2.0",
+                        "jsonpointer": "4.0.1",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    }
+                },
+                "is-obj": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+                    "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+                    "dev": true
+                },
+                "is-posix-bracket": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                    "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+                    "dev": true
+                },
+                "is-primitive": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                    "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+                    "dev": true
+                },
+                "is-property": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                    "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+                    "dev": true
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                    "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+                    "dev": true
+                },
+                "is-utf8": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+                    "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                    "dev": true
+                },
+                "is-valid-glob": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+                    "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "isobject": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                    "dev": true,
+                    "requires": {
+                        "isarray": "1.0.0"
+                    }
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                    "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                    "dev": true
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                    "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+                    "dev": true,
+                    "optional": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                    "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+                    "dev": true
+                },
+                "json-stable-stringify": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                    "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+                    "dev": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                    "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                    "dev": true
+                },
+                "jsonify": {
+                    "version": "0.0.0",
+                    "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                    "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+                    "dev": true
+                },
+                "jsonpointer": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+                    "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+                    "dev": true
+                },
+                "jsprim": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+                    "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.3.0",
+                        "json-schema": "0.2.3",
+                        "verror": "1.10.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                },
+                "lazystream": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+                    "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.3"
+                    }
+                },
+                "lodash._basecopy": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                    "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                    "dev": true
+                },
+                "lodash._basetostring": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                    "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                    "dev": true
+                },
+                "lodash._basevalues": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                    "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+                    "dev": true
+                },
+                "lodash._getnative": {
+                    "version": "3.9.1",
+                    "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                    "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+                    "dev": true
+                },
+                "lodash._isiterateecall": {
+                    "version": "3.0.9",
+                    "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                    "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+                    "dev": true
+                },
+                "lodash._reescape": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+                    "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+                    "dev": true
+                },
+                "lodash._reevaluate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+                    "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+                    "dev": true
+                },
+                "lodash._reinterpolate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+                    "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+                    "dev": true
+                },
+                "lodash._root": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                    "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+                    "dev": true
+                },
+                "lodash.escape": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+                    "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+                    "dev": true,
+                    "requires": {
+                        "lodash._root": "3.0.1"
+                    }
+                },
+                "lodash.isarguments": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                    "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                    "dev": true
+                },
+                "lodash.isarray": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                    "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                    "dev": true
+                },
+                "lodash.isequal": {
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+                    "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+                    "dev": true
+                },
+                "lodash.keys": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                    "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                    "dev": true,
+                    "requires": {
+                        "lodash._getnative": "3.9.1",
+                        "lodash.isarguments": "3.1.0",
+                        "lodash.isarray": "3.0.4"
+                    }
+                },
+                "lodash.restparam": {
+                    "version": "3.6.1",
+                    "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                    "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+                    "dev": true
+                },
+                "lodash.template": {
+                    "version": "3.6.2",
+                    "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+                    "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+                    "dev": true,
+                    "requires": {
+                        "lodash._basecopy": "3.0.1",
+                        "lodash._basetostring": "3.0.1",
+                        "lodash._basevalues": "3.0.0",
+                        "lodash._isiterateecall": "3.0.9",
+                        "lodash._reinterpolate": "3.0.0",
+                        "lodash.escape": "3.2.0",
+                        "lodash.keys": "3.1.2",
+                        "lodash.restparam": "3.6.1",
+                        "lodash.templatesettings": "3.1.1"
+                    }
+                },
+                "lodash.templatesettings": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+                    "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+                    "dev": true,
+                    "requires": {
+                        "lodash._reinterpolate": "3.0.0",
+                        "lodash.escape": "3.2.0"
+                    }
+                },
+                "map-stream": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+                    "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+                    "dev": true
+                },
+                "merge-stream": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+                    "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.3"
+                    }
+                },
+                "micromatch": {
+                    "version": "2.3.11",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.4"
+                    },
+                    "dependencies": {
+                        "is-extglob": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                            "dev": true
+                        },
+                        "is-glob": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                            "dev": true,
+                            "requires": {
+                                "is-extglob": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "mime-db": {
+                    "version": "1.30.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+                    "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.17",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+                    "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.30.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "0.0.8",
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                            "dev": true
+                        }
+                    }
+                },
+                "mocha": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+                    "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+                    "dev": true,
+                    "requires": {
+                        "browser-stdout": "1.3.0",
+                        "commander": "2.11.0",
+                        "debug": "3.1.0",
+                        "diff": "3.3.1",
+                        "escape-string-regexp": "1.0.5",
+                        "glob": "7.1.2",
+                        "growl": "1.10.3",
+                        "he": "1.1.1",
+                        "mkdirp": "0.5.1",
+                        "supports-color": "4.4.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "4.4.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+                            "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "2.0.0"
+                            }
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "multimatch": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+                    "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+                    "dev": true,
+                    "requires": {
+                        "array-differ": "1.0.0",
+                        "array-union": "1.0.2",
+                        "arrify": "1.0.1",
+                        "minimatch": "3.0.4"
+                    }
+                },
+                "multipipe": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                    "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+                    "dev": true,
+                    "requires": {
+                        "duplexer2": "0.0.2"
+                    }
+                },
+                "node.extend": {
+                    "version": "1.1.6",
+                    "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+                    "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+                    "dev": true,
+                    "requires": {
+                        "is": "3.2.1"
+                    }
+                },
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "1.1.0"
+                    }
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                    "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+                    "dev": true
+                },
+                "object-assign": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                    "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+                    "dev": true
+                },
+                "object.omit": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                    "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+                    "dev": true,
+                    "requires": {
+                        "for-own": "0.1.5",
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "ordered-read-streams": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+                    "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+                    "dev": true,
+                    "requires": {
+                        "is-stream": "1.1.0",
+                        "readable-stream": "2.3.3"
+                    }
+                },
+                "parse-glob": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                    "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+                    "dev": true,
+                    "requires": {
+                        "glob-base": "0.3.0",
+                        "is-dotfile": "1.0.3",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1"
+                    },
+                    "dependencies": {
+                        "is-extglob": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                            "dev": true
+                        },
+                        "is-glob": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                            "dev": true,
+                            "requires": {
+                                "is-extglob": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "path-dirname": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+                    "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+                    "dev": true
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                    "dev": true
+                },
+                "pause-stream": {
+                    "version": "0.0.11",
+                    "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+                    "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+                    "dev": true,
+                    "requires": {
+                        "through": "2.3.8"
+                    }
+                },
+                "pend": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+                    "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+                    "dev": true
+                },
+                "pinkie": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                    "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                    "dev": true
+                },
+                "pinkie-promise": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                    "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                    "dev": true,
+                    "requires": {
+                        "pinkie": "2.0.4"
+                    }
+                },
+                "preserve": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                    "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.3.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+                    "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+                    "dev": true
+                },
+                "queue": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+                    "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "randomatic": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                    "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "3.0.0",
+                        "kind-of": "4.0.0"
+                    },
+                    "dependencies": {
+                        "is-number": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "3.2.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "1.1.6"
+                                    }
+                                }
+                            }
+                        },
+                        "kind-of": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                            "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                    "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "regex-cache": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+                    "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-equal-shallow": "0.1.3"
+                    }
+                },
+                "remove-trailing-separator": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+                    "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+                    "dev": true
+                },
+                "repeat-element": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                    "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+                    "dev": true
+                },
+                "repeat-string": {
+                    "version": "1.6.1",
+                    "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                    "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+                    "dev": true
+                },
+                "rimraf": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+                    "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.4.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+                    "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+                    "dev": true
+                },
+                "sntp": {
+                    "version": "1.0.9",
+                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                    "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "source-map-support": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+                    "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+                    "dev": true,
+                    "requires": {
+                        "source-map": "0.6.1"
+                    }
+                },
+                "sparkles": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                    "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+                    "dev": true
+                },
+                "split": {
+                    "version": "0.3.3",
+                    "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+                    "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+                    "dev": true,
+                    "requires": {
+                        "through": "2.3.8"
+                    }
+                },
+                "sshpk": {
+                    "version": "1.13.1",
+                    "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                    "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+                    "dev": true,
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "stat-mode": {
+                    "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+                    "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
+                    "dev": true
+                },
+                "stream-combiner": {
+                    "version": "0.0.4",
+                    "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                    "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+                    "dev": true,
+                    "requires": {
+                        "duplexer": "0.1.1"
+                    }
+                },
+                "stream-shift": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                    "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+                    "dev": true
+                },
+                "streamfilter": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz",
+                    "integrity": "sha1-h1BxEb644phFFxe1Ec/tjwAqv1M=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.3"
+                    }
+                },
+                "streamifier": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+                    "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                },
+                "stringstream": {
+                    "version": "0.0.5",
+                    "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                    "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                    "dev": true,
+                    "requires": {
+                        "is-utf8": "0.2.1"
+                    }
+                },
+                "strip-bom-stream": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+                    "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+                    "dev": true,
+                    "requires": {
+                        "first-chunk-stream": "1.0.0",
+                        "strip-bom": "2.0.0"
+                    }
                 },
                 "supports-color": {
-                    "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-                    "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                     "dev": true
                 },
-                "tunnel-agent": {
-                    "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+                "tar": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                    "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+                    "dev": true,
+                    "requires": {
+                        "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "through": {
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                    "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
                     "dev": true
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.3",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "through2-filter": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+                    "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+                    "dev": true,
+                    "requires": {
+                        "through2": "2.0.3",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "time-stamp": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+                    "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+                    "dev": true
+                },
+                "to-absolute-glob": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+                    "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "2.0.1"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+                    "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+                    "dev": true,
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                    "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+                    "dev": true
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                    "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+                    "dev": true,
+                    "optional": true
+                },
+                "unique-stream": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+                    "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+                    "dev": true,
+                    "requires": {
+                        "json-stable-stringify": "1.0.1",
+                        "through2-filter": "2.0.0"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+                    "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+                    "dev": true
+                },
+                "vali-date": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+                    "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+                    "dev": true
+                },
+                "verror": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                    "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "extsprintf": "1.3.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "vinyl": {
+                    "version": "0.5.3",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+                    "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.3",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
+                },
+                "vinyl-fs": {
+                    "version": "2.4.4",
+                    "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+                    "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+                    "dev": true,
+                    "requires": {
+                        "duplexify": "3.5.1",
+                        "glob-stream": "5.3.5",
+                        "graceful-fs": "4.1.11",
+                        "gulp-sourcemaps": "1.6.0",
+                        "is-valid-glob": "0.3.0",
+                        "lazystream": "1.0.0",
+                        "lodash.isequal": "4.5.0",
+                        "merge-stream": "1.0.1",
+                        "mkdirp": "0.5.1",
+                        "object-assign": "4.1.1",
+                        "readable-stream": "2.3.3",
+                        "strip-bom": "2.0.0",
+                        "strip-bom-stream": "1.0.0",
+                        "through2": "2.0.3",
+                        "through2-filter": "2.0.0",
+                        "vali-date": "1.0.0",
+                        "vinyl": "1.2.0"
+                    },
+                    "dependencies": {
+                        "object-assign": {
+                            "version": "4.1.1",
+                            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                            "dev": true
+                        },
+                        "vinyl": {
+                            "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                            "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                            "dev": true,
+                            "requires": {
+                                "clone": "1.0.3",
+                                "clone-stats": "0.0.1",
+                                "replace-ext": "0.0.1"
+                            }
+                        }
+                    }
+                },
+                "vinyl-source-stream": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
+                    "integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
+                    "dev": true,
+                    "requires": {
+                        "through2": "0.6.5",
+                        "vinyl": "0.4.6"
+                    },
+                    "dependencies": {
+                        "clone": {
+                            "version": "0.2.0",
+                            "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                            "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                            "dev": true
+                        },
+                        "isarray": {
+                            "version": "0.0.1",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                            "dev": true
+                        },
+                        "readable-stream": {
+                            "version": "1.0.34",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "0.0.1",
+                                "string_decoder": "0.10.31"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "0.10.31",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                            "dev": true
+                        },
+                        "through2": {
+                            "version": "0.6.5",
+                            "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                            "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                            "dev": true,
+                            "requires": {
+                                "readable-stream": "1.0.34",
+                                "xtend": "4.0.1"
+                            }
+                        },
+                        "vinyl": {
+                            "version": "0.4.6",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                            "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                            "dev": true,
+                            "requires": {
+                                "clone": "0.2.0",
+                                "clone-stats": "0.0.1"
+                            }
+                        }
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                    "dev": true
+                },
+                "xtend": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                    "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                    "dev": true
+                },
+                "yauzl": {
+                    "version": "2.9.1",
+                    "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+                    "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+                    "dev": true,
+                    "requires": {
+                        "buffer-crc32": "0.2.13",
+                        "fd-slicer": "1.0.1"
+                    }
+                },
+                "yazl": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
+                    "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
+                    "dev": true,
+                    "requires": {
+                        "buffer-crc32": "0.2.13"
+                    }
                 }
             }
         },
         "vso-node-api": {
             "version": "6.1.2-preview",
             "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.1.2-preview.tgz",
-            "integrity": "sha1-qrNUbfJFHs2JTgcbuZtd8Zxfp48="
-        },
-        "which": {
-            "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-            "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-            "dev": true
-        },
-        "widest-line": {
-            "version": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-            "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
-            "dev": true,
-            "dependencies": {
-                "string-width": {
-                    "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "dev": true
-                }
+            "integrity": "sha1-qrNUbfJFHs2JTgcbuZtd8Zxfp48=",
+            "requires": {
+                "q": "1.5.0",
+                "tunnel": "0.0.4",
+                "typed-rest-client": "0.9.0",
+                "underscore": "1.8.3"
             }
-        },
-        "wordwrap": {
-            "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-            "dev": true
         },
         "wrappy": {
             "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
-        "write-file-atomic": {
-            "version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-            "integrity": "sha1-fUW6MjFjKN0ex9kPYOvA2EW7dZo=",
-            "dev": true
-        },
-        "xdg-basedir": {
-            "version": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-            "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-            "dev": true
-        },
-        "xtend": {
-            "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-            "dev": true
-        },
-        "yallist": {
-            "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-            "dev": true
-        },
         "yauzl": {
             "version": "https://registry.npmjs.org/yauzl/-/yauzl-2.7.0.tgz",
-            "integrity": "sha1-4h2EeGi0lvwp6uwj7of90z6bK84="
+            "integrity": "sha1-4h2EeGi0lvwp6uwj7of90z6bK84=",
+            "requires": {
+                "buffer-crc32": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+                "fd-slicer": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+            }
         },
         "yazl": {
             "version": "https://registry.npmjs.org/yazl/-/yazl-2.4.2.tgz",
-            "integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg="
+            "integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg=",
+            "requires": {
+                "buffer-crc32": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -107,6 +107,48 @@
                     "Delphi",
                     "Object Pascal"
                 ]
+            },
+            {
+                "id": "crystal",
+                "extensions": [
+                    ".cr"
+                ],
+                "aliases": [
+                    "Crystal",
+                    "crystal"
+                ]
+            },
+            {
+                "id": "julia",
+                "extensions": [
+                    ".jl"
+                ],
+                "aliases": [
+                    "Julia",
+                    "julia"
+                ]
+            },
+            {
+                "id": "nim",
+                "extensions": [
+                    ".nim"
+                ],
+                "aliases": [
+                    "Nim",
+                    "nim",
+                    "Nimrod",
+                    "nimrod"
+                ]
+            },
+            {
+                "id": "nimble",
+                "extensions": [
+                    ".nimble"
+                ],
+                "aliases": [
+                    "Nimble",
+                    "nimble"
+                ]
             }
         ],
         "configuration": {

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -93,18 +93,22 @@ const swift = new Notation("swift", ["/**", " */"], "//", " * ");
 const xml = new Notation("xml", ["<!--", "-->"], "", "");
 
 // custom languages
-const d = new Notation( "d", ["/*", " */"], "//", " *");
+const crystal = new Notation("crystal", ["", ""], "#", " ");
+const d = new Notation("d", ["/*", " */"], "//", " *");
 const erlang = new Notation("erlang", ["", ""], "%%", "");
 const handlebars = new Notation("handlebars", ["<!--", "-->"], "", " ");
 const haskell = new Notation("haskell", ["{--", "-}"], "--", " - ");
+const julia = new Notation("julia", ["#=", " =#"], "#", " ");
 const lisp = new Notation("lisp", ["", ""], ";;", "");
+const nim = new Notation("nim", ["", ""], "#", " ");
+const nimble = new Notation("nimble", ["", ""], "#", " ");
 const ocaml = new Notation("ocaml", ["(**", " *)"], "", " * ");
 const pascal = new Notation("pascal", ["(*", "*)"], "//", "")
 
 // map betweeen languageId and its comment notations.
 // LanguageId is listed here.
 // https://code.visualstudio.com/docs/languages/identifiers
-export const notations: {[key: string]: Notation} = {
+export const notations: { [key: string]: Notation } = {
     "bat": bat,
     "c": c,
     "clojure": lisp,
@@ -139,11 +143,15 @@ export const notations: {[key: string]: Notation} = {
     "swift": swift,
     "xml": xml,
 
+    "crystal": crystal,
     "d": d,
     "erlang": erlang,
     "handlebars": handlebars,
     "haskell": haskell,
+    "julia": julia,
     "lisp": lisp,
+    "nim": nim,
+    "nimble": nimble,
     "ocaml": ocaml,
     "pascal": pascal,
 }


### PR DESCRIPTION
Support for Julia, Crystal, Nim and Nimble has been added in the same patch, since they use basically the same rules for comments.

Except for Julia, all the languages have single line comments, using hash as token.

Tests are passing and headers work as expected