### PR TITLE
update apache2 license by removing copyright from short version

### DIFF
--- a/src/licenses/al2.ts
+++ b/src/licenses/al2.ts
@@ -232,9 +232,7 @@ export class AL2 {
     }
 
     public header(): string {
-        let template = `   Copyright ${this.year} ${this.author}
-
-   Licensed under the Apache License, Version 2.0 (the "License");
+        let template = `Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 


### PR DESCRIPTION
According to the Apache2 license documentation the short version of the license should not include the copyright header.

> "Each source file should include the following license header -- note that there should be no copyright notice in the header:"

see: https://www.apache.org/legal/src-headers.html#headers

This PR updates the apache2 license by removing the copyright.

Thank you for your work on this plugin!!