### PR TITLE
Always indent multi-line comments by one space

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ to create a LICENSE file based on the configurations in `settings.json`. This ex
 not only provides shortcuts but also enables auto-insertion of license header on creation
 of new file.
 
-You can call these 2 commands via Command Palette. 
+You can call these 2 commands via Command Palette.
 * "licenser: Create LICENSE file"
   * create LICENSE file into your repository.
 * "licenser: Insert license header"
@@ -121,10 +121,10 @@ license header template.
 "licenser.projectName": "Awesome project"
 ```
 
-**This setting should be in Workspace settings.** This setting defines the project name you are working on. 
-This setting is only used in the template for GPLv2 and GPLv3. Default value would be 
-your workspace root directory name. Be aware that this setting should be in Workspace setting, 
-not in User setting, since User setting affects all workspaces which are not relevant to this project name. 
+**This setting should be in Workspace settings.** This setting defines the project name you are working on.
+This setting is only used in the template for GPLv2 and GPLv3. Default value would be
+your workspace root directory name. Be aware that this setting should be in Workspace setting,
+not in User setting, since User setting affects all workspaces which are not relevant to this project name.
 
 ### licenser.useSingleLineStyle
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -361,7 +361,7 @@ class Licenser {
 
         for (let i in original) {
             if (original.length > 0) {
-                header += ornament + original[i] + "\n";
+                header += ornament + " " + original[i] + "\n";
             }
         }
         header += end + "\n";

--- a/src/licenses/ccby40.ts
+++ b/src/licenses/ccby40.ts
@@ -77,7 +77,7 @@ exhaustive, and do not form part of our licenses.
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More_considerations
-     for the public: 
+     for the public:
 	wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================

--- a/src/licenses/ccbync40.ts
+++ b/src/licenses/ccbync40.ts
@@ -77,7 +77,7 @@ exhaustive, and do not form part of our licenses.
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More_considerations
-     for the public: 
+     for the public:
 	wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================

--- a/src/licenses/ccbyncnd40.ts
+++ b/src/licenses/ccbyncnd40.ts
@@ -77,7 +77,7 @@ exhaustive, and do not form part of our licenses.
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More_considerations
-     for the public: 
+     for the public:
 	wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================

--- a/src/licenses/ccbyncsa40.ts
+++ b/src/licenses/ccbyncsa40.ts
@@ -77,7 +77,7 @@ exhaustive, and do not form part of our licenses.
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More_considerations
-     for the public: 
+     for the public:
 	wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================

--- a/src/licenses/ccbynd40.ts
+++ b/src/licenses/ccbynd40.ts
@@ -77,9 +77,9 @@ exhaustive, and do not form part of our licenses.
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More_considerations
-     for the public: 
+     for the public:
 	wiki.creativecommons.org/Considerations_for_licensees
-	
+
 
 =======================================================================
 

--- a/src/licenses/ccbysa40.ts
+++ b/src/licenses/ccbysa40.ts
@@ -77,7 +77,7 @@ exhaustive, and do not form part of our licenses.
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More_considerations
-     for the public: 
+     for the public:
 	wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================

--- a/src/licenses/gplv2.ts
+++ b/src/licenses/gplv2.ts
@@ -387,8 +387,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with ${ this.productName }.  If not, see <http://www.gnu.org/licenses/>.
-`
+along with ${ this.productName }.  If not, see <http://www.gnu.org/licenses/>.`
         return template;
     }
 }

--- a/src/licenses/gplv3.ts
+++ b/src/licenses/gplv3.ts
@@ -279,8 +279,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with ${ this.productName }.  If not, see <http://www.gnu.org/licenses/>.
-`
+along with ${ this.productName }.  If not, see <http://www.gnu.org/licenses/>.`
         return template;
     }
 }

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -1,11 +1,11 @@
 //    Copyright 2016, 2017 Yoshi Yamaguchi
-// 
+//
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
 //    You may obtain a copy of the License at
-// 
+//
 //        http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -63,46 +63,46 @@ class Notation {
 
 // init (alphabetical order)
 const bat = new Notation("bat", ["", ""], "rem", "");
-const c = new Notation("c", ["/**", " */"], "", " * ");
+const c = new Notation("c", ["/**", " */"], "", " *");
 const cpp = new Notation("cpp", ["/**", " */"], "//", " *");
-const csharp = new Notation("csharp", ["/**", " */"], "//", " * ");
+const csharp = new Notation("csharp", ["/**", " */"], "//", " *");
 const css = new Notation("css", ["/**", " */"], "", " *");
 const dockerfile = new Notation("dockerfile", ["", ""], "#", " ");
-const fsharp = new Notation("fsharp", ["(**", " *)"], "//", " * ");
+const fsharp = new Notation("fsharp", ["(**", " *)"], "//", " *");
 const go = new Notation("go", ["/**", " */"], "//", " *");
-const groovy = new Notation("groovy", ["/**", " */"], "//", " * ");
-const html = new Notation("html", ["<!--", "-->"], "", " ");
+const groovy = new Notation("groovy", ["/**", " */"], "//", " *");
+const html = new Notation("html", ["<!--", "-->"], "", "");
 const ini = new Notation("ini", ["", ""], ";", "");
 const java = new Notation("java", ["/**", " */"], "//", " *");
-const javascript = new Notation("javascript", ["/**", " */"], "//", " * ");
-const lua = new Notation("lua", ["--[[", "--]]"], "--", " ");
+const javascript = new Notation("javascript", ["/**", " */"], "//", " *");
+const lua = new Notation("lua", ["--[[", "--]]"], "--", "");
 const makefile = new Notation("makefile", ["", ""], "#", "");
-const markdown = new Notation("markdown", ["<!---", "-->"], "", " ");
-const objectivec = new Notation("objective-c", ["/**", " */"], "//", " * ");
-const perl = new Notation("perl", ["=pod", "=cut"], "#", " ");
-const php = new Notation("php", ["/**", " */"], "//", " * ");
+const markdown = new Notation("markdown", ["<!--", "-->"], "", "");
+const objectivec = new Notation("objective-c", ["/**", " */"], "//", " *");
+const perl = new Notation("perl", ["=pod", "=cut"], "#", "");
+const php = new Notation("php", ["/**", " */"], "//", " *");
 const plaintext = new Notation("plaintext", ["", ""], "//", ""); // TODO(ymotongpoo): add feature to support custom single line comment style. (#15)
-const powershell = new Notation("powershell", ["<##", "#>"], "#", " # ");
-const python = new Notation("python", ['"""', '"""'], "#", " ");
-const ruby = new Notation("ruby", ["=begin", "=end"], "#", " ");
-const rust = new Notation("rust", ["/**", " */"], "//", " * ");
-const typescript = new Notation("typescript", ["/**", " */"], "//", " * ");
-const scss = new Notation("scss", ["/**", " */"], "//", " * ");
-const shellscript = new Notation("shellscript", ["<<LICENSE", ">>"], "#", " ");
-const swift = new Notation("swift", ["/**", " */"], "//", " * ");
+const powershell = new Notation("powershell", ["<##", "#>"], "#", " #");
+const python = new Notation("python", ['"""', '"""'], "#", "");
+const ruby = new Notation("ruby", ["=begin", "=end"], "#", "");
+const rust = new Notation("rust", ["/**", " */"], "//", " *");
+const typescript = new Notation("typescript", ["/**", " */"], "//", " *");
+const scss = new Notation("scss", ["/**", " */"], "//", " *");
+const shellscript = new Notation("shellscript", ["<<LICENSE", ">>"], "#", "");
+const swift = new Notation("swift", ["/**", " */"], "//", " *");
 const xml = new Notation("xml", ["<!--", "-->"], "", "");
 
 // custom languages
-const crystal = new Notation("crystal", ["", ""], "#", " ");
+const crystal = new Notation("crystal", ["", ""], "#", "");
 const d = new Notation("d", ["/*", " */"], "//", " *");
 const erlang = new Notation("erlang", ["", ""], "%%", "");
-const handlebars = new Notation("handlebars", ["<!--", "-->"], "", " ");
-const haskell = new Notation("haskell", ["{--", "-}"], "--", " - ");
-const julia = new Notation("julia", ["#=", " =#"], "#", " ");
+const handlebars = new Notation("handlebars", ["<!--", "-->"], "", "");
+const haskell = new Notation("haskell", ["{--", "-}"], "--", " -");
+const julia = new Notation("julia", ["#=", " =#"], "#", "");
 const lisp = new Notation("lisp", ["", ""], ";;", "");
-const nim = new Notation("nim", ["", ""], "#", " ");
-const nimble = new Notation("nimble", ["", ""], "#", " ");
-const ocaml = new Notation("ocaml", ["(**", " *)"], "", " * ");
+const nim = new Notation("nim", ["", ""], "#", "");
+const nimble = new Notation("nimble", ["", ""], "#", "");
+const ocaml = new Notation("ocaml", ["(**", " *)"], "", " *");
 const pascal = new Notation("pascal", ["(*", "*)"], "//", "")
 
 // map betweeen languageId and its comment notations.


### PR DESCRIPTION
This matches the behaviour for single line comments by removing trailing spaces from ornaments and applying them in `multiLineCommentHeader`