### PR TITLE
Add missing space to multiLineCommentHeader

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -361,7 +361,7 @@ class Licenser {
 
         for (const line of original) {
             if (original.length > 0) {
-                header += ornament + line + "\n";
+                header += ornament + " " + line + "\n";
             }
         }
         header += end + "\n";


### PR DESCRIPTION
It got removed by the merge in f92a08e6f9ba6044f395834dd81260c7a9a61129