### PR TITLE
Implements multiple file license header insertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "activationEvents": [
         "onCommand:extension.insertLicenseHeader",
         "onCommand:extension.anyLicenseHeader",
-        "onCommand:extension.createLicenseFile"
+        "onCommand:extension.createLicenseFile",
+        "onCommand:extension.insertMultipleLicenseHeaders"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -242,8 +243,23 @@
             {
                 "command": "extension.createLicenseFile",
                 "title": "licenser: Create LICENSE file"
+            },
+            {
+                "command": "extension.insertMultipleLicenseHeaders",
+                "title": "licenser: Insert license headers to contents"
             }
         ],
+        "menus": {
+            "commandPalette": [{
+                "command": "extension.insertMultipleLicenseHeaders",
+                "when": "false"
+            }],
+            "explorer/context": [{
+                "when": "explorerResourceIsFolder",
+                "command": "extension.insertMultipleLicenseHeaders",
+                "group": "7_modification"
+            }]
+        },
         "keybindings": [
             {
                 "command": "extension.createLicenseFile",


### PR DESCRIPTION
Intended to close #32 

- Adds new command, only visible in context menu of folders in explorer.
- Recursively adds license headers to all files within a directory/subdirectories
  - Only inserts license header into files which do not contain one already

I tried my best to do this in a similar way to the original _insert function, but was unable to find a good way to go about it.  This currently uses the fs module to insert licenses.  This may be an inefficient way of accomplishing this task, so I can attempt to do it in a way that has similar behavior to _insert if desired, although it may be a bit uglier.