### PR TITLE
package.json - fix: missing property for BSL1

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
                         "AL2",
                         "BSD2",
                         "BSD3",
+                        "BSL1",
                         "GPLv2",
                         "GPLv3",
                         "LGPLv3",


### PR DESCRIPTION
in file: package.json
add an missing entry for the "Boost Software License 1.0" (BSL-1.0)