### PR TITLE
Use "objectpascal" as an alias for Pascal.

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,8 +104,8 @@
                 ],
                 "aliases": [
                     "Pascal",
-                    "Delphi",
-                    "Object Pascal"
+                    "delphi",
+                    "objectpascal"
                 ]
             },
             {


### PR DESCRIPTION
This is an attempt to fix #66.

As I do not have the necessary tools in my machine, it is hard for me to test whether it was actually fixed..