### PR TITLE
implements customHeaderFile and customTermsAndConditionsFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,17 @@ The following placeholders can be used:
 Other characters, such as double-quotes, may need to be escaped as well.
 Consider using a regex replace to convert an existing multi-line file to a single line.
 
+### licenser.customTermsAndConditionsFile
+
+```
+"licenser.customTermsAndConditionsFile": "path/to/terms.txt"
+```
+
+This setting defines the path to a file that contains the text for the custom terms and conditions.
+This will override `licenser.customTermsAndConditions` if present.
+
+Placeholders are the same as `licenser.customTermsAndConditions`.
+
 ### licenser.customHeader
 
 ```
@@ -193,6 +204,17 @@ Consider using a regex replace to convert an existing multi-line file to a singl
 This setting defines the text used to create the license header file when the "Custom" license type is selected.
 
 Placeholders and escaping requirements are the same as `licenser.customTermsAndConditions`.
+
+### licenser.customHeaderFile
+
+```
+"licenser.customHeaderFile": "path/to/header.txt"
+```
+
+This setting defines the path to a file that contains the text for the custom header.
+This will override `licenser.customHeader` if present.
+
+Placeholders are the same as `licenser.customTermsAndConditions`.
 
 ### licenser.disableAutoHeaderInsertion
 

--- a/package.json
+++ b/package.json
@@ -230,10 +230,20 @@
                     "default": "",
                     "description": "User-defined terms and conditions"
                 },
+                "licenser.customTermsAndConditionsFile": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Path to a file containing a user-defined custom terms and conditions. Overrides Custom Terms And Conditions when present."
+                },
                 "licenser.customHeader": {
                     "type": "string",
                     "default": "",
                     "description": "User-defined file header"
+                },
+                "licenser.customHeaderFile": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Path to a file containing a user-defined custom header. Overrides Custom Header when present."
                 },
                 "licenser.disableAutoHeaderInsertion": {
                     "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -340,9 +340,11 @@ class Licenser {
 
         if (licenseKey === "CUSTOM") {
             let customTermsAndConditions = licenserSetting.get<string>("customTermsAndConditions");
+            let customTermsAndConditionsFile = licenserSetting.get<string>("customTermsAndConditionsFile");
             let customHeader = licenserSetting.get<string>("customHeader");
+            let customHeaderFile = licenserSetting.get<string>("customHeaderFile");
             let fileName = vscode.window.activeTextEditor.document.fileName;
-            return new Custom(this.author, projectName, customTermsAndConditions, customHeader, fileName);
+            return new Custom(this.author, projectName, customTermsAndConditions, customTermsAndConditionsFile, customHeader, customHeaderFile, fileName);
         }
 
         let info = availableLicenses.get(licenseKey);

--- a/src/licenses/custom.ts
+++ b/src/licenses/custom.ts
@@ -16,6 +16,7 @@
 
 import { License } from "./type";
 import path = require("path");
+import fs = require("fs");
 
 export class Custom {
     public author: string;
@@ -25,7 +26,7 @@ export class Custom {
     public customHeader: string;
     public filePath: path.ParsedPath;
 
-    constructor(author: string, project: string, customTermsAndConditions: string, customHeader: string, filePath: string) {
+    constructor(author: string, project: string, customTermsAndConditions: string, customTermsAndConditionsFile: string, customHeader: string, customHeaderFile: string, filePath: string, ) {
         this.author = author;
         let date = new Date();
         this.year = date.getFullYear().toString();
@@ -33,6 +34,14 @@ export class Custom {
         this.customTermsAndConditions = customTermsAndConditions;
         this.customHeader = customHeader;
         this.filePath = path.parse(filePath);
+
+        if (customTermsAndConditionsFile) {
+            this.customHeader = fs.readFileSync(customTermsAndConditionsFile).toString();
+        }
+
+        if (customHeaderFile) {
+            this.customHeader = fs.readFileSync(customHeaderFile).toString();
+        }
     }
 
     private replaceVariables(text: string): string {


### PR DESCRIPTION
Adds 2 new settings:

1. customTermsAndConditionsFile: Path to a file containing a user-defined custom terms and conditions. Overrides Custom Terms And Conditions when present.
2. customHeaderFile: Path to a file containing a user-defined custom header. Overrides Custom Header when present.

This allows users to put a custom header and/or terms and conditions in a file of their choice, instead of trying to fit it all into a single-line setting. I think this makes custom licenses easier to use and also mitigates #77 