### PR TITLE
Make multiple file mode respects shebang and outputs file names correctly.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -228,10 +228,13 @@ class Licenser {
             await vscode.workspace.openTextDocument(openSetting).then(doc => {
                 langId = doc.languageId;
             });
+            license.filePath = path.parse(fullPath);
             const header = this.getLicenseHeader(license, langId);
-            let fileContent = fs.readFileSync(fullPath);
+            let fileContent = fs.readFileSync(fullPath) + '';
             if (!fileContent.includes(header)) {
-                const newFileContent = header + fileContent;
+                const firstLine = fileContent.split('\n', 1)[0] +'\n';
+                const position = this.findInsertionPosition(firstLine, langId);
+                const newFileContent = fileContent.substring(0, position) + header + fileContent.substring(position);
                 try {
                     fs.writeFileSync(fullPath, newFileContent);
                     console.log("Inserted license header");


### PR DESCRIPTION
The original method to add license to multiple files does not respect shebang in shell script or PHP file.
And the FILE field in custom license will incorrectly filled with the current file opened in the editor.
This pull request attempts to fix this two issues.