### PR TITLE
Added support to environment variables

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -228,7 +228,8 @@ class Licenser {
             await vscode.workspace.openTextDocument(openSetting).then(doc => {
                 langId = doc.languageId;
             });
-            license.filePath = path.parse(fullPath);
+            //license.filePath = path.parse(fullPath);
+
             const header = this.getLicenseHeader(license, langId);
             let fileContent = fs.readFileSync(fullPath) + '';
             if (!fileContent.includes(header)) {

--- a/src/licenses/custom.ts
+++ b/src/licenses/custom.ts
@@ -17,6 +17,7 @@
 import { License } from "./type";
 import path = require("path");
 import fs = require("fs");
+import * as vscode from 'vscode';
 
 export class Custom {
     public author: string;
@@ -36,12 +37,44 @@ export class Custom {
         this.filePath = path.parse(filePath);
 
         if (customTermsAndConditionsFile) {
-            this.customHeader = fs.readFileSync(customTermsAndConditionsFile).toString();
+            this.customHeader = fs.readFileSync(this.evaluateEnvVars(customTermsAndConditionsFile)).toString();
         }
 
         if (customHeaderFile) {
-            this.customHeader = fs.readFileSync(customHeaderFile).toString();
+            this.customHeader = fs.readFileSync(this.evaluateEnvVars(customHeaderFile)).toString();
         }
+    }
+
+    private evaluateEnvVars(value : string) : string {
+
+        if (value == null) 
+            return '';
+
+            try 
+            {
+                return value.replace(/\$\{(.*?)\}/g, (source, match) => {
+
+                    // support for os environment variables
+                    Object.keys(process.env).forEach(function(key) {
+                        if (key == match)
+                            return process.env[key]
+                    });
+
+                    // support for custom variables mapped from vscode.
+                    switch(match)
+                    {
+                        case 'workspaceFolder':
+                            return vscode.workspace.rootPath;
+
+                        default: 
+                            return '';
+                    }
+                });
+            }
+            catch(error)
+            {
+                return '';
+            }
     }
 
     private replaceVariables(text: string): string {


### PR DESCRIPTION
Fix #93 - Adding support to environment variables (custom mapped and OS env vars )
Notes: I faced problems when trying to use vscode.workspace.getWorkspaceFolder() instead I decided to use rootPath of the workspace (I don't know if this approach is the best option)

Deleted `license.filePath = path.parse(fullPath)` because it is causing the error `error TS2339: Property 'filePath' does not exist on type 'License'.`

Feel free to suggest changes 
Cya ;)