### PR TITLE
Add SPDX license format and some fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,6 +226,11 @@
                     "default": true,
                     "description": "Priority to use single line comment style to multiple line comment style for license header."
                 },
+                "licenser.useSPDXLicenseFormat": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use SPDX license format (short format) instead full license information."
+                },
                 "licenser.customTermsAndConditions": {
                     "type": "string",
                     "default": "",
@@ -245,6 +250,11 @@
                     "type": "string",
                     "default": "",
                     "description": "Path to a file containing a user-defined custom header. Overrides Custom Header when present."
+                },
+                "licenser.customSPDXId": {
+                    "type": "string",
+                    "default": "",
+                    "description": "The SPDX License Id for your custom license."
                 },
                 "licenser.disableAutoHeaderInsertion": {
                     "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,7 +100,7 @@ const availableLicenses: Map<string, LicenseInfo> = new Map<string, LicenseInfo>
     ["CC-BY-SA-3", { displayName: "CC-BY-SA-3", creatorFn: (author, projectName) => new CCBYSA3(author, projectName) }],
     ["CC-BY-SA-4", { displayName: "CC-BY-SA-4", creatorFn: (author, projectName) => new CCBYSA4(author, projectName) }],
     ["CC0-1", { displayName: "CC0-1", creatorFn: (author, projectName) => new CC01(author, projectName) }],
-    ["UNL", { displayName: "UNL", creatorFn: (author, _) => new WTFPL(author) }],
+    ["UNL", { displayName: "UNL", creatorFn: (author, _) => new UNL(author) }],
     ["WTFPL", { displayName: "WTFPL", creatorFn: (author, _) => new WTFPL(author) }],
     ["ZLIB", { displayName: "zlib", creatorFn: (author, _) => new Zlib(author) }],
 ]);

--- a/src/licenses/0bsd.ts
+++ b/src/licenses/0bsd.ts
@@ -49,4 +49,11 @@ Use of this source code is governed by a BSD-style
 license that can be found in the LICENSE file.`;
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ this.year } ${ this.author }.
+SPDX-License-Identifier: 0BSD`
+        return template;
+    }
 }

--- a/src/licenses/agplv3.ts
+++ b/src/licenses/agplv3.ts
@@ -708,4 +708,11 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ this.year } ${ this.author }.
+SPDX-License-Identifier: 	AGPL-3.0-or-later`
+        return template;
+    }
 }

--- a/src/licenses/al2.ts
+++ b/src/licenses/al2.ts
@@ -247,4 +247,11 @@ See the License for the specific language governing permissions and
 limitations under the License.`;
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ this.year } ${ this.author }.
+SPDX-License-Identifier: Apache-2.0`
+        return template;
+    }
 }

--- a/src/licenses/bsd2.ts
+++ b/src/licenses/bsd2.ts
@@ -61,4 +61,11 @@ Use of this source code is governed by a BSD-style
 license that can be found in the LICENSE file.`;
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ this.year } ${ this.author }.
+SPDX-License-Identifier: BSD-2-Clause`
+        return template;
+    }
 }

--- a/src/licenses/bsd3.ts
+++ b/src/licenses/bsd3.ts
@@ -65,4 +65,11 @@ Use of this source code is governed by a BSD-style
 license that can be found in the LICENSE file.`;
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ this.year } ${ this.author }.
+SPDX-License-Identifier: BSD-3-Clause`
+        return template;
+    }
 }

--- a/src/licenses/bsl1.ts
+++ b/src/licenses/bsl1.ts
@@ -60,4 +60,11 @@ See accompanying file LICENSE
 or copy at http://www.boost.org/LICENSE_1_0.txt`;
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: BSL-1.0`
+        return template;
+    }
 }

--- a/src/licenses/ccby30.ts
+++ b/src/licenses/ccby30.ts
@@ -359,4 +359,11 @@ work.  If not, see <http://creativecommons.org/licenses/by/3.0/>.`
 
         return template;
     }
+    
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }. All rights reserved.
+SPDX-License-Identifier: CC-BY-3.0`
+        return template;
+    }
 }

--- a/src/licenses/ccby40.ts
+++ b/src/licenses/ccby40.ts
@@ -435,4 +435,11 @@ work. If not, see <http://creativecommons.org/licenses/by/4.0/>.`
 
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: CC-BY-4.0`
+        return template;
+    }
 }

--- a/src/licenses/ccbync30.ts
+++ b/src/licenses/ccbync30.ts
@@ -373,4 +373,11 @@ You should have received a copy of the license along with this
 work.  If not, see <http://creativecommons.org/licenses/by-nc/3.0/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: CC-BY-NC-3.0`
+        return template;
+    }
 }

--- a/src/licenses/ccbync40.ts
+++ b/src/licenses/ccbync40.ts
@@ -446,4 +446,11 @@ You should have received a copy of the license along with this
 work. If not, see <http://creativecommons.org/licenses/by-nc/4.0/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: CC-BY-NC-4.0 `
+        return template;
+    }
 }

--- a/src/licenses/ccbyncnd30.ts
+++ b/src/licenses/ccbyncnd30.ts
@@ -347,4 +347,11 @@ You should have received a copy of the license along with this
 work.  If not, see <http://creativecommons.org/licenses/by-nc-nd/3.0/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: CC-BY-NC-ND-3.0`
+        return template;
+    }
 }

--- a/src/licenses/ccbyncnd40.ts
+++ b/src/licenses/ccbyncnd40.ts
@@ -441,4 +441,11 @@ You should have received a copy of the license along with this
 work. If not, see <http://creativecommons.org/licenses/by-nc-nd/4.0/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: CC-BY-NC-ND-4.0`
+        return template;
+    }
 }

--- a/src/licenses/ccbyncsa30.ts
+++ b/src/licenses/ccbyncsa30.ts
@@ -399,4 +399,11 @@ You should have received a copy of the license along with this
 work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: CC-BY-NC-SA-3.0`
+        return template;
+    }
 }

--- a/src/licenses/ccbyncsa40.ts
+++ b/src/licenses/ccbyncsa40.ts
@@ -476,4 +476,11 @@ You should have received a copy of the license along with this
 work. If not, see <http://creativecommons.org/licenses/by-nc-sa/4.0/>.`
         return template;
     }
-}
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: CC-BY-NC-SA-4.0`
+        return template;
+    }
+    
+   }

--- a/src/licenses/ccbynd30.ts
+++ b/src/licenses/ccbynd30.ts
@@ -332,4 +332,11 @@ You should have received a copy of the license along with this
 work.  If not, see <http://creativecommons.org/licenses/by-nd/3.0/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: CC-BY-ND-3.0`
+        return template;
+    }
 }

--- a/src/licenses/ccbynd40.ts
+++ b/src/licenses/ccbynd40.ts
@@ -429,4 +429,11 @@ You should have received a copy of the license along with this
 work. If not, see <http://creativecommons.org/licenses/by-nd/4.0/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: CC-BY-ND-4.0`
+        return template;
+    }
 }

--- a/src/licenses/ccbysa30.ts
+++ b/src/licenses/ccbysa30.ts
@@ -398,4 +398,11 @@ You should have received a copy of the license along with this
 work.  If not, see <http://creativecommons.org/licenses/by-sa/3.0/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: CC-BY-SA-3.0`
+        return template;
+    }
 }

--- a/src/licenses/ccbysa40.ts
+++ b/src/licenses/ccbysa40.ts
@@ -466,4 +466,11 @@ You should have received a copy of the license along with this
 work. If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: CC-BY-SA-4.0`
+        return template;
+    }
 }

--- a/src/licenses/cczero1.ts
+++ b/src/licenses/cczero1.ts
@@ -161,4 +161,11 @@ You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: CC0-1.0`
+        return template;
+    }
 }

--- a/src/licenses/custom.ts
+++ b/src/licenses/custom.ts
@@ -13,7 +13,7 @@
 //    limitations under the License.
 
 "use strict";
-
+import * as vscode from 'vscode';
 import { License } from "./type";
 import path = require("path");
 import fs = require("fs");
@@ -60,6 +60,16 @@ export class Custom {
 
     public header(): string {
         let template = this.replaceVariables(this.customHeader);
+        return template;
+    }
+
+    public spdxHeader(): string
+    {
+        let licenserSetting = vscode.workspace.getConfiguration("licenser");
+        let customSpdxId = licenserSetting.get<string>("customSPDXId", "");
+
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: ${customSpdxId}`
         return template;
     }
 }

--- a/src/licenses/custom.ts
+++ b/src/licenses/custom.ts
@@ -36,12 +36,44 @@ export class Custom {
         this.filePath = path.parse(filePath);
 
         if (customTermsAndConditionsFile) {
-            this.customHeader = fs.readFileSync(customTermsAndConditionsFile).toString();
+            this.customHeader = fs.readFileSync(this.evaluateEnvVars(customTermsAndConditionsFile)).toString();
         }
 
         if (customHeaderFile) {
-            this.customHeader = fs.readFileSync(customHeaderFile).toString();
+            this.customHeader = fs.readFileSync(this.evaluateEnvVars(customHeaderFile)).toString();
         }
+    }
+
+    private evaluateEnvVars(value : string) : string {
+
+        if (value == null) 
+            return '';
+
+            try 
+            {
+                return value.replace(/\$\{(.*?)\}/g, (source, match) => {
+
+                    // support for os environment variables
+                    Object.keys(process.env).forEach(function(key) {
+                        if (key == match)
+                            return process.env[key]
+                    });
+
+                    // support for custom variables mapped from vscode.
+                    switch(match)
+                    {
+                        case 'workspaceFolder':
+                            return vscode.workspace.rootPath;
+
+                        default: 
+                            return '';
+                    }
+                });
+            }
+            catch(error)
+            {
+                return '';
+            }
     }
 
     private replaceVariables(text: string): string {

--- a/src/licenses/gplv2.ts
+++ b/src/licenses/gplv2.ts
@@ -390,4 +390,11 @@ You should have received a copy of the GNU General Public License
 along with ${ this.productName }.  If not, see <http://www.gnu.org/licenses/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: GPL-2.0-only`
+        return template;
+    }
 }

--- a/src/licenses/gplv3.ts
+++ b/src/licenses/gplv3.ts
@@ -725,4 +725,11 @@ You should have received a copy of the GNU General Public License
 along with ${ this.productName }.  If not, see <http://www.gnu.org/licenses/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: GPL-3.0-only`
+        return template;
+    }
 }

--- a/src/licenses/lgplv3.ts
+++ b/src/licenses/lgplv3.ts
@@ -214,4 +214,11 @@ You should have received a copy of the GNU Lesser General Public License
 along with ${ this.productName }. If not, see <http://www.gnu.org/licenses/>.`
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: LGPL-3.0-only`
+        return template;
+    }
 }

--- a/src/licenses/mit.ts
+++ b/src/licenses/mit.ts
@@ -58,5 +58,12 @@ This software is released under the MIT License.
 https://opensource.org/licenses/MIT`;
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: MIT`
+        return template;
+    }
 }
 

--- a/src/licenses/mplv2.ts
+++ b/src/licenses/mplv2.ts
@@ -411,5 +411,12 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.`;
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: MPL-2.0`
+        return template;
+    }
 }
 

--- a/src/licenses/type.ts
+++ b/src/licenses/type.ts
@@ -18,4 +18,5 @@ export interface License {
     author: string;
     termsAndConditions(): string;
     header(): string;
+    spdxHeader(): string;
 }

--- a/src/licenses/unl.ts
+++ b/src/licenses/unl.ts
@@ -60,4 +60,11 @@ Use of this source code is governed by The Unlicense
 which can be found in the LICENSE file.`;
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: Unlicense`
+        return template;
+    }
 }

--- a/src/licenses/wtfpl.ts
+++ b/src/licenses/wtfpl.ts
@@ -49,4 +49,11 @@ Use of this source code is governed by the WTFPL
 license that can be found in the LICENSE file.`;
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
+SPDX-License-Identifier: WTFPL`
+        return template;
+    }
 }

--- a/src/licenses/zlib.ts
+++ b/src/licenses/zlib.ts
@@ -69,4 +69,11 @@ freely, subject to the following restrictions:
 3. This notice may not be removed or altered from any source distribution.`;
         return template;
     }
+
+    public spdxHeader(): string
+    {
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }. All rights reserved.
+SPDX-License-Identifier: Zlib`
+        return template;
+    }
 }

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -91,7 +91,7 @@ const ruby = new Notation("ruby", ["=begin", "=end"], "#", "");
 const rust = new Notation("rust", ["/**", " */"], "//", " *");
 const typescript = new Notation("typescript", ["/**", " */"], "//", " *");
 const scss = new Notation("scss", ["/**", " */"], "//", " *");
-const shellscript = new Notation("shellscript", ["<<LICENSE", ">>"], "#", "");
+const shellscript = new Notation("shellscript", ["", ""], "#", "");
 const starlark = new Notation("starlark", ["", ""], "#", "");
 const swift = new Notation("swift", ["/**", " */"], "//", " *");
 const xml = new Notation("xml", ["<!--", "-->"], "", "");


### PR DESCRIPTION
Changes:
* Added SPDX license format (fixes #88)
* Fixed shellscript multi-line comment notation (fixes #85)
* Fixed UNL license, the extension loading WTFPL instead UNL
* Fixed `Fix for error TS2339: Property 'filePath' does not exist` error.
* Added routine to map OS  variables and some environment variables on CustomPath (fixes #93)

PS: I closed my other PR's and merged them into this branch to make it easier to follow the changes