### PR TITLE
Set onStartupFinished activate event to initialize extension on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
         "onCommand:extension.insertLicenseHeader",
         "onCommand:extension.anyLicenseHeader",
         "onCommand:extension.createLicenseFile",
-        "onCommand:extension.insertMultipleLicenseHeaders"
+        "onCommand:extension.insertMultipleLicenseHeaders",
+        "onStartupFinished"
     ],
     "main": "./out/src/extension",
     "contributes": {

--- a/package.json
+++ b/package.json
@@ -280,6 +280,10 @@
             {
                 "command": "extension.insertMultipleLicenseHeaders",
                 "title": "licenser: Insert license headers to contents"
+            },
+            {
+                "command": "extension.InsertLicensesOnEntireWorkspace",
+                "title": "licenser: Insert license headers to all files on the workspace."
             }
         ],
         "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,6 +127,8 @@ class Licenser {
         vscode.commands.registerCommand("extension.anyLicenseHeader", () => { this.arbitrary() });
         vscode.commands.registerCommand("extension.insertLicenseHeader", () => { this.insert() });
         vscode.commands.registerCommand("extension.insertMultipleLicenseHeaders", (context) => { this.insertMultiple(context) });
+        vscode.commands.registerCommand("extension.InsertLicensesOnEntireWorkspace", () => { this.insertMultiple(null) });
+        
         vscode.window.onDidChangeActiveTextEditor(this._onDidChangeActiveTextEditor, this, subscriptions)
     }
 
@@ -224,7 +226,7 @@ class Licenser {
         files.forEach(async (file) => {
             let langId = null;
             const fullPath = path.join(dirPath, file);
-            const openSetting = vscode.Uri.parse("file:///" + fullPath);
+            const openSetting = vscode.Uri.parse("file://" + fullPath);
             await vscode.workspace.openTextDocument(openSetting).then(doc => {
                 langId = doc.languageId;
             });
@@ -274,7 +276,7 @@ class Licenser {
         let licenserSetting = vscode.workspace.getConfiguration("licenser");
         let licenseType = licenserSetting.get<string>("license");
         const license = this.getLicense(licenseType);
-        let folderPath = context.fsPath;
+        let folderPath = context != null && context != undefined ? context.fsPath: vscode.workspace.rootPath;
         this._insertMultiple(license, folderPath);
     }
 

--- a/src/licenses/zlib.ts
+++ b/src/licenses/zlib.ts
@@ -72,7 +72,7 @@ freely, subject to the following restrictions:
 
     public spdxHeader(): string
     {
-        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }. All rights reserved.
+        let template = `Copyright ${ new Date().getFullYear().toString() } ${ this.author }.
 SPDX-License-Identifier: Zlib`
         return template;
     }


### PR DESCRIPTION
Changes
* Added the activate event to force initialization of extension when vscode starts (fixes #98).
* Added the 'insert licenses into all files' command (fixes #84)
* Fixed the uri.parse that throwing an exception `Error: [UriError]: If a URI does not contain an authority component, then the path cannot begin with two slash characters ("//") `