### PR TITLE
Fix reading the author from configuration.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -449,7 +449,7 @@ class Licenser {
      *   3. OS environment.
      */
     private getAuthor(): string {
-        let licenserSetting = vscode.workspace.getConfiguration("licenser.author");
+        let licenserSetting = vscode.workspace.getConfiguration("licenser");
         let author = licenserSetting.get<string>("author", undefined);
         console.log("Author from setting: " + author);
         if (author !== undefined && author.length !== 0) {


### PR DESCRIPTION
A change introduced in dfbce5e1796eeefa782235f7c8e1cb2de58401d9 broke how the extension reads the author's name, always defaulting to the computer user name. This PR reverts this change.