### PR TITLE
fix: svelte and vue templates follow html really

### DIFF
--- a/src/notation.ts
+++ b/src/notation.ts
@@ -150,7 +150,9 @@ export const notations: { [key: string]: Notation } = {
     "scss": scss,
     "shellscript": shellscript,
     "starlark": starlark,
+    "svelte": html,
     "swift": swift,
+    "vue": html,
     "xml": xml,
 
     "crystal": crystal,


### PR DESCRIPTION
Allow svelte and vue files to have comments inserted in them as per html format