### PR TITLE
ignore undefined in onDidChangeActiveTextEditor

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -315,6 +315,9 @@ class Licenser {
 
     private _onDidChangeActiveTextEditor() {
         vscode.window.onDidChangeActiveTextEditor(e => {
+            if (e === undefined) {
+                return;
+            }
             let licenserSetting = vscode.workspace.getConfiguration("licenser");
             let autoInsertionDisabled = licenserSetting.get<boolean>("disableAutoHeaderInsertion");
             if (autoInsertionDisabled) {


### PR DESCRIPTION
Ignore undefined elements that onDidChangeActiveTextEditor can (and is
documented to) send to licenser. This cleans up a lot of noise in
vscode's `Log (Window)` but doesn't change licenser's behavior since
licenser would crash on the `e.document.fileName` later in the code.
