### PR TITLE
Feature: Exlude files based on their extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ Placeholders are the same as `licenser.customTermsAndConditions`.
 This setting defines the behavior of header auto-insertion.
 If this setting is set as `true`, licenser will disable auto-insertion of license header on creation of new file.
 
+
+### licenser.excludeFileExtensions
+
+```
+"licenser.excludeFileExtensions": ["txt", "c"]
+```
+This setting will exclude files with a matching extension in their name from having a license header auto inserted. There is no limit in the amount of entries this array can have. This setting is case insensitive. 
 ## Call to action
 
 ### Report issues

--- a/package.json
+++ b/package.json
@@ -267,6 +267,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Disable auto save after an operation (defaults to false)."
+                },
+                "licenser.excludeFileExtensions": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Exclude files from having a license automatically inserted based on file extension."
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -324,6 +324,22 @@ class Licenser {
                 return;
             }
             const fileName = path.win32.basename(e.document.fileName);
+
+            if (fileName.includes(".") && !fileName.endsWith(".")) {
+                const fileExtension = fileName.substring(fileName.lastIndexOf(".") + 1, fileName.length).toLocaleLowerCase();
+
+                let exludedFileExtensions = licenserSetting.get<string[]>("excludeFileExtensions");
+
+                const isInExcludedInList = exludedFileExtensions.some((e) => {
+                    return e.toLocaleLowerCase() === fileExtension
+                });
+
+                if (isInExcludedInList) {
+                    console.log("File: " + fileName + " exluded based on extension: " + fileExtension);
+                    return;
+                }
+            }
+
             if (fileName !== defaultLicenseFilename) {
                 const doc = e.document;
                 const contents = doc.getText();


### PR DESCRIPTION
Hello first of all thank you for your great extension!

This PR adds the possibility for users to exclude certain file extensions. Sometimes when working on projects you can be working with files where the licenses don't make much sense. Therefor it can be a nice feature to have to possibility to disable the automatic header insertion for them only. As for now you only have two options: Delete the header every time or disable the auto insertion. And of course this is completely optional so current behavior isn't changed.

I hope you consider my addition.
