### PR TITLE
Remove stray tab in AGPLv3 SPDX header

### DIFF
--- a/src/licenses/agplv3.ts
+++ b/src/licenses/agplv3.ts
@@ -712,7 +712,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.`
     public spdxHeader(): string
     {
         let template = `Copyright ${ this.year } ${ this.author }.
-SPDX-License-Identifier: 	AGPL-3.0-or-later`
+SPDX-License-Identifier: AGPL-3.0-or-later`
         return template;
     }
 }


### PR DESCRIPTION
Hi! Thanks for the great extension! 

I noticed a stray tab character in the AGPLv3 SPDX header template, and I wanted to propose removing it. I took a quick peek at the other licenses, and it looks like AGPL is the only one affected.